### PR TITLE
Fix setuptools-scm tag matching in monorepo

### DIFF
--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -56,7 +56,6 @@ root = ".."
 # Generate version file
 version_file = "src/wt_compiler/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-compiler/v*"]
-fallback_version = "0.1.0.dev0"
 
 [tool.uv.sources]
 # Development override - uses local editable wt-contracts

--- a/wt-contracts/pyproject.toml
+++ b/wt-contracts/pyproject.toml
@@ -52,7 +52,6 @@ root = ".."
 # Generate version file
 version_file = "src/wt_contracts/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-contracts/v*"]
-fallback_version = "0.1.0.dev0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/wt_contracts"]

--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -21,7 +21,6 @@ tag_regex = "^wt-invokers-gcp/v(?P<version>[0-9.]+)$"
 root = ".."
 version_file = "src/wt_invokers_gcp/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-invokers-gcp/v*"]
-fallback_version = "0.1.0.dev0"
 
 # ============================================================================
 # Pixi Build Configuration (conda package building)

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -57,7 +57,6 @@ root = ".."
 # Generate version file
 version_file = "src/wt_invokers/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-invokers/v*"]
-fallback_version = "0.1.0.dev0"
 
 [tool.uv.sources]
 # Development override - uses local editable wt-contracts

--- a/wt-registry/pyproject.toml
+++ b/wt-registry/pyproject.toml
@@ -55,7 +55,6 @@ root = ".."
 # Generate version file
 version_file = "src/wt_registry/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-registry/v*"]
-fallback_version = "0.1.0.dev0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/wt_registry"]

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -24,7 +24,6 @@ tag_regex = "^wt-runner-gcp/v(?P<version>[0-9.]+)$"
 root = ".."
 version_file = "src/wt_runner_gcp/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-runner-gcp/v*"]
-fallback_version = "0.1.0.dev0"
 
 # ============================================================================
 # Pixi Build Configuration (conda package building)

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -56,7 +56,6 @@ root = ".."
 # Generate version file
 version_file = "src/wt_runner/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-runner/v*"]
-fallback_version = "0.1.0.dev0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/wt-task-gcp/pyproject.toml
+++ b/wt-task-gcp/pyproject.toml
@@ -22,7 +22,6 @@ tag_regex = "^wt-task-gcp/v(?P<version>[0-9.]+)$"
 root = ".."
 version_file = "src/wt_task_gcp/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-task-gcp/v*"]
-fallback_version = "0.1.0.dev0"
 
 # ============================================================================
 # Pixi Build Configuration (conda package building)

--- a/wt-task/pyproject.toml
+++ b/wt-task/pyproject.toml
@@ -60,8 +60,6 @@ root = ".."
 # Generate version file
 version_file = "src/wt_task/_version.py"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "wt-task/v*"]
-# Fallback version for development without git
-fallback_version = "0.1.0.dev0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
another fast-follow to fix #53 following failures such as https://github.com/wildlife-dynamics/wt/actions/runs/22734387321

**Context**
wt-contracts 0.1.0 was successfully published to PyPI with tag wt-contracts/v0.1.0. Now when building wt-registry (or any other package), setuptools-scm runs git describe which finds the nearest tag — wt-contracts/v0.1.0 — regardless of which package is being built. The tag_regex filter is applied after git describe returns, so it gets the wrong tag, can’t parse it, and fails with AssertionError.

**Fix**
Add git_describe_command with --match to each package’s [tool.setuptools_scm] config. This makes git describe only consider tags for the specific package being built, so it won’t pick up tags from other packages.

Also remove the existing fallback_version from wt-task for consistency — builds should fail clearly if no tag exists.