### PR TITLE
Fix incorrect license metadata

### DIFF
--- a/wt-compiler/README.md
+++ b/wt-compiler/README.md
@@ -274,4 +274,4 @@ See main wt repository CONTRIBUTING.md for guidelines.
 
 ## License
 
-MIT
+BSD-3-Clause

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -8,9 +8,16 @@ dynamic = ["version"]
 description = "Workflow compiler for generating DAG artifacts from workflow specifications"
 requires-python = ">=3.12"
 readme = "README.md"
-license = { text = "MIT" }
+license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Ecoscope Team" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "wt-contracts>=0.1.0,<1.0.0",

--- a/wt-contracts/README.md
+++ b/wt-contracts/README.md
@@ -96,4 +96,4 @@ uv run ruff check .
 
 ## License
 
-MIT
+BSD-3-Clause

--- a/wt-contracts/pyproject.toml
+++ b/wt-contracts/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Shared interface contracts for wt workflow packages"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "BSD-3-Clause" }
 authors = [
     { name = "wt Contributors" }
 ]
@@ -16,7 +16,7 @@ keywords = ["workflow", "contracts", "interfaces", "types"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -7,6 +7,10 @@ name = "wt-invokers-gcp"
 dynamic = ["version"]
 description = "Metapackage bundling wt-invokers with GCP dependencies (Cloud Batch)"
 requires-python = ">=3.10"
+license = { text = "BSD-3-Clause" }
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+]
 dependencies = [
     "wt-invokers>=0.1.0,<1.0.0",
     "google-cloud-batch>=0.19.0",

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Abstract invoker interface and implementations for wt workflows"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Workflow Tools Contributors" }
 ]
@@ -16,7 +16,7 @@ keywords = ["workflow", "invoker", "execution", "subprocess", "cloud"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -7,6 +7,10 @@ name = "wt-runner-gcp"
 dynamic = ["version"]
 description = "Metapackage bundling wt-runner with GCP dependencies (Pub/Sub, tracing, Cloud Batch)"
 requires-python = ">=3.13,<3.16"
+license = { text = "BSD-3-Clause" }
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+]
 dependencies = [
     "wt-runner>=0.1.0,<1.0.0",
     "ecoscope-eda-core @ git+https://github.com/wildlife-dynamics/ecoscope-eda-core.git",

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -7,6 +7,14 @@ name = "wt-runner"
 dynamic = ["version"]
 description = "FastAPI application for workflow execution using wt-invokers"
 requires-python = ">=3.13,<3.16"
+license = { text = "BSD-3-Clause" }
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "wt-contracts>=0.1.0,<1.0.0",
     "wt-invokers>=0.1.0,<1.0.0",

--- a/wt-task-gcp/pyproject.toml
+++ b/wt-task-gcp/pyproject.toml
@@ -7,6 +7,10 @@ name = "wt-task-gcp"
 dynamic = ["version"]
 description = "Metapackage bundling wt-task with GCP tracing dependencies"
 requires-python = ">=3.10"
+license = { text = "BSD-3-Clause" }
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+]
 dependencies = [
     "wt-task>=0.1.0,<1.0.0",
     "opentelemetry-api>=1.20.0",

--- a/wt-task/README.md
+++ b/wt-task/README.md
@@ -173,4 +173,4 @@ uv run pytest tests/test_decorator.py
 
 ## License
 
-Apache-2.0
+BSD-3-Clause

--- a/wt-task/pyproject.toml
+++ b/wt-task/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Task decorator and execution features for wt ecosystem"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Ecoscope Workflows Team" }
 ]
@@ -16,7 +16,7 @@ keywords = ["workflow", "task", "execution", "decorator"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
fast-follow to #53 because the first set of pypi releases had some incorrect license metadata sprinkled about in pyproject.tomls and READMEs