### PR TITLE
Update CHANGELOGs for release 2026-03-13

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.0 — 2026-03-13
+
+- Support PyPI dependencies (`git`/`path`/`url` sources) in workflow specs, emitted as `[pypi-dependencies]` in compiled `pixi.toml` ([#60](https://github.com/wildlife-dynamics/wt/pull/60))
+- Generalize compiled `ResponseModel.result` from `DashboardJson | OutputFiles` to `Any`, removing hard dependency on `ecoscope_workflows_core` types ([#61](https://github.com/wildlife-dynamics/wt/pull/61))
+- Make Graphviz graph generation best-effort — warns instead of failing when `dot` binary is unavailable ([#60](https://github.com/wildlife-dynamics/wt/pull/60))
+- Add `wt_registry` entry-point auto-discovery to task discovery pipeline ([#60](https://github.com/wildlife-dynamics/wt/pull/60))
+
 ## v0.1.1 — 2026-03-05
 
 - Fix incorrect license metadata

--- a/wt-contracts/CHANGELOG.md
+++ b/wt-contracts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2 — 2026-03-13
+
+- Bootstrap release for prefix.dev conda channel
+
 ## v0.1.1 — 2026-03-05
 
 - Fix incorrect license metadata

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2 — 2026-03-13
+
+- Bootstrap release for prefix.dev conda channel
+
 ## v0.1.1 — 2026-03-05
 
 - Fix incorrect license metadata

--- a/wt-registry/CHANGELOG.md
+++ b/wt-registry/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0 — 2026-03-13
+
+- Add `auto_discover()` for entry-point-based task module discovery ([#60](https://github.com/wildlife-dynamics/wt/pull/60))
+- CLI now auto-discovers task modules via `wt_registry` entry points before processing explicit `--package` args ([#60](https://github.com/wildlife-dynamics/wt/pull/60))
+
 ## v0.1.0 — 2026-03-05
 
 - Initial release

--- a/wt-runner/CHANGELOG.md
+++ b/wt-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2 — 2026-03-13
+
+- Bootstrap release for prefix.dev conda channel
+
 ## v0.1.1 — 2026-03-05
 
 - Fix incorrect license metadata

--- a/wt-task/CHANGELOG.md
+++ b/wt-task/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2 — 2026-03-13
+
+- `configure_tracer()` and `attach_context()` now warn instead of raising `ImportError` when tracing deps are missing ([#60](https://github.com/wildlife-dynamics/wt/pull/60))
+
 ## v0.1.1 — 2026-03-05
 
 - Fix incorrect license metadata


### PR DESCRIPTION
## Summary

- Update CHANGELOGs for all 6 core packages ahead of tagging
- wt-registry 0.2.0, wt-compiler 0.2.0 (new features)
- wt-task 0.1.2 (bugfix)
- wt-contracts 0.1.2, wt-invokers 0.1.2, wt-runner 0.1.2 (bootstrap to prefix.dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)