### PR TITLE
Update publish.yml to install rattler-index

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,11 +53,13 @@ jobs:
           pixi-version: v0.63.0
           run-install: false
 
+      - name: Install rattler-build & rattler-index
+        run: |
+          pixi global install rattler-build
+          pixi global install rattler-index
+
       - name: Build conda package
         run: ./scripts/build-conda-packages.sh ${{ needs.parse.outputs.package }}
-
-      - name: Install rattler-build
-        run: pixi global install rattler-build
 
       - name: Upload to prefix.dev
         run: |


### PR DESCRIPTION
Added installation of rattler-index to publish.yml to fix failure seen in [Merge pull request #67 from wildlife-dynamics/release/2026-03-13](https://github.com/wildlife-dynamics/wt/actions/runs/23068259752)

Towards #48.

