### PR TITLE
Fix conda package versioning

### DIFF
--- a/.claude/commands/release-wt.md
+++ b/.claude/commands/release-wt.md
@@ -61,11 +61,12 @@ For each package being released:
    - Description of change 1
    - Description of change 2
    ```
-4. After preparing all CHANGELOG updates, ask the user for final confirmation before committing
-5. Commit **all** CHANGELOG updates in a single commit (message: `Update CHANGELOGs for release`)
-6. Push the release branch and create a PR to `main` via `gh pr create`. Include today's date in the PR title (e.g., `Update CHANGELOGs for release YYYY-MM-DD`) to avoid duplicate PR names across releases.
-7. Ask the user to merge the PR (branch protection requires a PR to update `main`)
-8. After the user confirms the PR is merged, checkout `main` and pull to get the merge commit — tags must point to commits on `main`
+4. Update `[tool.pixi.package] version` in each released package's `pyproject.toml` to match the new version. For GCP metapackages released in lockstep, update their `pyproject.toml` too.
+5. After preparing all CHANGELOG and pyproject.toml updates, ask the user for final confirmation before committing
+6. Commit **all** CHANGELOG and pyproject.toml updates in a single commit (message: `Update CHANGELOGs and pixi versions for release`)
+7. Push the release branch and create a PR to `main` via `gh pr create`. Include today's date in the PR title (e.g., `Update CHANGELOGs for release YYYY-MM-DD`) to avoid duplicate PR names across releases.
+8. Ask the user to merge the PR (branch protection requires a PR to update `main`)
+9. After the user confirms the PR is merged, checkout `main` and pull to get the merge commit — tags must point to commits on `main`
 
 ## Step 6 — Tag and push
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Run `/release-wt` in Claude Code for an interactive assistant that:
 - Analyzes changes and recommends version bumps
 - Generates per-package release notes from diffs/commits
 - Updates each package's `CHANGELOG.md`
+- Syncs `[tool.pixi.package] version` in each package's `pyproject.toml` (required for correct conda package versions)
 - Creates annotated tags (with notes embedded) and pushes with confirmation
 
 ### Manual release

--- a/scripts/build-conda-packages.sh
+++ b/scripts/build-conda-packages.sh
@@ -96,7 +96,19 @@ build_package() {
         return 1
     fi
 
-    # Set version for setuptools-scm
+    # Verify [tool.pixi.package] version matches the git-tag-derived version.
+    # Release packages with the /release-wt Claude command to keep this in sync.
+    local pyproject="$pkg_dir/pyproject.toml"
+    local pixi_version
+    pixi_version=$(awk '/^\[tool\.pixi\.package\]/{found=1; next} /^\[/{found=0} found && /^version/ {gsub(/[" ]/, ""); sub(/version=/, ""); print; exit}' "$pyproject")
+    if [[ "$pixi_version" != "$version" ]]; then
+        log_error "[tool.pixi.package] version in $pyproject is '$pixi_version' but expected '$version' (from git tag)"
+        log_error "Release packages with the /release-wt Claude command to synchronize versions, or manually update [tool.pixi.package] version in $pyproject"
+        return 1
+    fi
+
+    # Set version for setuptools-scm (controls the Python package version
+    # inside the conda package, i.e. the installed wheel's __version__)
     export SETUPTOOLS_SCM_PRETEND_VERSION="$version"
 
     # Build the package

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -111,7 +111,7 @@ ignore = []
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.1.0"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-contracts/pyproject.toml
+++ b/wt-contracts/pyproject.toml
@@ -104,7 +104,7 @@ ignore = []
 
 [tool.pixi.package]
 name = "wt-contracts"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -32,7 +32,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -144,7 +144,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-registry/pyproject.toml
+++ b/wt-registry/pyproject.toml
@@ -101,7 +101,7 @@ files = ["src/wt_registry"]
 
 [tool.pixi.package]
 name = "wt-registry"
-version = "0.1.0"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -35,7 +35,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-runner-gcp"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -119,7 +119,7 @@ extend-immutable-calls = [
 
 [tool.pixi.package]
 name = "wt-runner"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-task-gcp/pyproject.toml
+++ b/wt-task-gcp/pyproject.toml
@@ -33,7 +33,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-task-gcp"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-task/pyproject.toml
+++ b/wt-task/pyproject.toml
@@ -123,7 +123,7 @@ ignore = [
 
 [tool.pixi.package]
 name = "wt-task"
-version = "0.1.0"
+version = "0.1.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
towards #48

This is motivated by the realization that the version of wt-contracts publish by https://github.com/wildlife-dynamics/wt/actions/runs/23068718177 to prefix was inconsistent with PyPI:
- `0.1.0` on prefix https://prefix.dev/channels/ecoscope-workflows/packages/wt-contracts
- `0.1.2` on pypi https://pypi.org/project/wt-contracts/0.1.2/#history

Claude summary follows

## Summary

- Add version validation to `build-conda-packages.sh` — fails with descriptive error if `[tool.pixi.package] version` doesn't match the git-tag-derived version
- Update `/release-wt` command to sync `[tool.pixi.package] version` as part of the release flow
- Update all 9 `pyproject.toml` files to current release versions (were stuck at `0.1.0`)
- Document pixi version sync in README

**Root cause:** `pixi build` reads the conda package version from `[tool.pixi.package] version` in `pyproject.toml`, ignoring `SETUPTOOLS_SCM_PRETEND_VERSION`. The hardcoded `0.1.0` was being used for all conda packages regardless of the git tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)