### PR TITLE
Remove direct git reference from wt-runner[gcp] extras

### DIFF
--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -29,12 +29,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Google Cloud Platform dependencies (tracing, Pub/Sub, ecoscope-eda-core)
+# Google Cloud Platform dependencies (tracing, Pub/Sub)
+# Note: ecoscope-eda-core is excluded here because PyPI forbids direct git
+# references in extras. Install it separately or use the wt-runner-gcp conda
+# metapackage which includes it.
 gcp = [
     "opentelemetry-sdk>=1.37.0,<2",
     "opentelemetry-exporter-gcp-trace>=1.9.0,<2",
     "gcloud-aio-pubsub>=6.1.0,<7",
-    "ecoscope-eda-core @ git+https://github.com/wildlife-dynamics/ecoscope-eda-core.git",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Towards #48 (not strictly necessary for the prefix release, but for completeness)

This is to fix https://github.com/wildlife-dynamics/wt/actions/runs/23070415602

`wt-runner[gcp]` will not actually work without this dep, but:

1. we actually don't use this extra from pypi in production (we use pixi)
2. we want to bootstrap our first releases to pypi to reserve the package names there

Claude's summary follows.

## Summary

- Remove `ecoscope-eda-core @ git+...` from `wt-runner[gcp]` extras — PyPI forbids direct git references
- The dep is still available via the `wt-runner-gcp` conda metapackage

Needed to unblock the `wt-runner/v0.1.2` PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)