### PR TITLE
Bump wt-runner to 0.1.3 for re-release

### DIFF
--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -35,7 +35,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-runner-gcp"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner/CHANGELOG.md
+++ b/wt-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3 — 2026-03-13
+
+- Remove direct git reference from `wt-runner[gcp]` extras to fix PyPI publishing ([#71](https://github.com/wildlife-dynamics/wt/pull/71))
+
 ## v0.1.2 — 2026-03-13
 
 - Bootstrap release for prefix.dev conda channel

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -121,7 +121,7 @@ extend-immutable-calls = [
 
 [tool.pixi.package]
 name = "wt-runner"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

- Bump wt-runner and wt-runner-gcp to 0.1.3 (v0.1.2 tag collided on prefix.dev)
- Add CHANGELOG entry for 0.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)