### PR TITLE
Update CHANGELOGs for release 2026-03-18

### DIFF
--- a/wt-runner-gcp/CHANGELOG.md
+++ b/wt-runner-gcp/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changelog
+
+## v0.1.4 — 2026-03-18
+
+- Constrain Python to `<3.14` for ecoscope-eda-core compatibility
+- Bundle ecoscope-eda-core transitive dependencies (`aiohttp`, `pydantic`, `gcloud-aio-pubsub`, `stamina`)
+- Add dev dependencies, test configuration, and import verification tests

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -55,7 +55,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-runner-gcp"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner/CHANGELOG.md
+++ b/wt-runner/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.4 — 2026-03-18
+
+- Constrain Python to `<3.14` for ecoscope-eda-core compatibility
+- Bundle ecoscope-eda-core transitive dependencies (`aiohttp`, `pydantic`, `stamina`) in `[gcp]` extras
+
 ## v0.1.3 — 2026-03-13
 
 - Remove direct git reference from `wt-runner[gcp]` extras to fix PyPI publishing ([#71](https://github.com/wildlife-dynamics/wt/pull/71))

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -129,7 +129,7 @@ extend-immutable-calls = [
 
 [tool.pixi.package]
 name = "wt-runner"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

- Bump `wt-runner` and `wt-runner-gcp` to v0.1.4
- Add CHANGELOG entries for both packages
- Update pixi versions in pyproject.toml

### Changes in this release

**wt-runner:**
- Constrain Python to `<3.14` for ecoscope-eda-core compatibility
- Bundle ecoscope-eda-core transitive dependencies (`aiohttp`, `pydantic`, `stamina`) in `[gcp]` extras

**wt-runner-gcp:**
- Constrain Python to `<3.14` for ecoscope-eda-core compatibility
- Bundle ecoscope-eda-core transitive dependencies (`aiohttp`, `pydantic`, `gcloud-aio-pubsub`, `stamina`)
- Add dev dependencies, test configuration, and import verification tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)