### PR TITLE
Update CHANGELOGs for release 2026-03-19

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.0 — 2026-03-19
+
+- Add CI and Tag GitHub Actions workflow templates to the wizard scaffold ([#83](https://github.com/wildlife-dynamics/wt/pull/83))
+- Add `.gitignore` template to the wizard scaffold ([#83](https://github.com/wildlife-dynamics/wt/pull/83))
+- Add `linux-aarch64` platform support ([#83](https://github.com/wildlife-dynamics/wt/pull/83))
+- Fix wizard template rendering for nested output paths ([#83](https://github.com/wildlife-dynamics/wt/pull/83))
+- Pin compiled output version bounds for wt-task (`>=0.1.2`) and wt-runner (`>=0.1.4`) ([#96](https://github.com/wildlife-dynamics/wt/pull/96))
+- Remove errant injection of wt-task into wt-runner conda environment ([#96](https://github.com/wildlife-dynamics/wt/pull/96))
+- Pin `datamodel-code-generator` to `==0.42.1` ([#96](https://github.com/wildlife-dynamics/wt/pull/96))
+
 ## v0.2.0 — 2026-03-13
 
 - Support PyPI dependencies (`git`/`path`/`url` sources) in workflow specs, emitted as `[pypi-dependencies]` in compiled `pixi.toml` ([#60](https://github.com/wildlife-dynamics/wt/pull/60))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -111,7 +111,7 @@ ignore = []
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

closes #99 

- Release wt-compiler v0.3.0

## Test plan

- [x] Verify CHANGELOG entry is correct
- [x] Verify pyproject.toml version is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)