### PR TITLE
Update CHANGELOGs for release 2026-03-27

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.0 — 2026-03-27
+
+- Add `wt-compiler scaffold init` command for scaffolding new workflow projects with interactive (questionary) and `--no-interactive` batch modes ([#84](https://github.com/wildlife-dynamics/wt/pull/84), [#103](https://github.com/wildlife-dynamics/wt/pull/103))
+- Add custom wizard provider plugin system — third-party packages can ship providers via the `wt_compiler.wizard_providers` entry point ([#103](https://github.com/wildlife-dynamics/wt/pull/103))
+- Add `questionary>=2.0.0,<3.0.0` dependency for interactive prompts ([#103](https://github.com/wildlife-dynamics/wt/pull/103))
+- Update compiled wt-runner lower bound to `>=0.1.5`
+
 ## v0.3.0 — 2026-03-19
 
 - Add CI and Tag GitHub Actions workflow templates to the wizard scaffold ([#83](https://github.com/wildlife-dynamics/wt/pull/83))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -112,7 +112,7 @@ ignore = []
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.3.0"
+version = "0.4.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-compiler/src/wt_compiler/compiler.py
+++ b/wt-compiler/src/wt_compiler/compiler.py
@@ -482,7 +482,7 @@ class DagCompiler(BaseModel):
         if self.wt_pypi_deps is None:
             # Conda mode: wt-runner comes from conda channel
             runner_conda_deps[runner_pkg] = NamelessMatchSpec.from_match_spec(
-                MatchSpec(f"{runner_channel}::{runner_pkg} >=0.1.4,<1.0.0")
+                MatchSpec(f"{runner_channel}::{runner_pkg} >=0.1.5,<1.0.0")
             )
         else:
             # PyPI mode: wt-runner goes in runner feature pypi-deps,

--- a/wt-runner-gcp/CHANGELOG.md
+++ b/wt-runner-gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5 — 2026-03-27
+
+- Lockstep release with wt-runner v0.1.5
+
 ## v0.1.4 — 2026-03-18
 
 - Constrain Python to `<3.14` for ecoscope-eda-core compatibility

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -55,7 +55,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-runner-gcp"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner/CHANGELOG.md
+++ b/wt-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5 — 2026-03-27
+
+- Fix errant injection of `wt-task` into the wt-runner conda environment
+
 ## v0.1.4 — 2026-03-18
 
 - Constrain Python to `<3.14` for ecoscope-eda-core compatibility

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -129,7 +129,7 @@ extend-immutable-calls = [
 
 [tool.pixi.package]
 name = "wt-runner"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

- **wt-compiler** `0.3.0` → `0.4.0`: new `scaffold init` command with interactive/batch wizard and provider plugin system
- **wt-runner** `0.1.4` → `0.1.5`: fix errant wt-task injection into runner conda environment
- **wt-runner-gcp** `0.1.4` → `0.1.5`: lockstep with wt-runner
- **wt-compiler/compiler.py**: bump compiled wt-runner lower bound to `>=0.1.5`

## Test plan

- [ ] PR passes CI
- [ ] Merge to main, then tag and push in dependency order

🤖 Generated with [Claude Code](https://claude.com/claude-code)