### PR TITLE
Add a display label to loop questions

### DIFF
--- a/wt-compiler/src/wt_compiler/cli.py
+++ b/wt-compiler/src/wt_compiler/cli.py
@@ -150,8 +150,8 @@ def _interactive_init(provider: AbstractWizardProvider) -> None:
     Loop boundaries are detected via ``wizard.loop_context`` injected by
     ``_process_question()``. When ``loop_context`` is present on a yielded
     question, a confirm prompt is shown before the question itself:
-    - ``iteration == 0``: "Add a {dest}?" (default True)
-    - ``iteration > 0``: "Add another {dest}?" (default True)
+    - ``iteration == 0``: "Add a {label}?" (default True)
+    - ``iteration > 0``: "Add another {label}?" (default True)
     If the user declines, ``""`` is sent to the generator to end the loop.
 
     Args:
@@ -177,8 +177,9 @@ def _interactive_init(provider: AbstractWizardProvider) -> None:
             loop_ctx: LoopContext | None = wizard_meta.get("loop_context")
             if loop_ctx is not None:
                 is_first = loop_ctx["iteration"] == 0
+                question_label = loop_ctx.get("label", loop_ctx["dest"])
                 confirm_msg = (
-                    f"Add a {loop_ctx['dest']}?" if is_first else f"Add another {loop_ctx['dest']}?"
+                    f"Add a {question_label}?" if is_first else f"Add another {question_label}?"
                 )
                 confirmed = questionary.confirm(confirm_msg, default=True).ask()
                 if confirmed is None:

--- a/wt-compiler/src/wt_compiler/wizard/README.md
+++ b/wt-compiler/src/wt_compiler/wizard/README.md
@@ -211,8 +211,8 @@ question["wizard"].get("loop_context")
 
 When `loop_context` is present, show a confirm prompt **before** rendering the question:
 
-- `iteration == 0` → "Add a {dest}?" (suggest `default=True`)
-- `iteration > 0` → "Add another {dest}?" (suggest `default=True`)
+- `iteration == 0` → "Add a {label}?" (suggest `default=True`)
+- `iteration > 0` → "Add another {label}?" (suggest `default=True`)
 
 If the user declines, send `""` to the generator — this is the loop termination signal
 (the `while answer:` guard exits the loop). The generator then yields the next top-level

--- a/wt-compiler/src/wt_compiler/wizard/abstract.py
+++ b/wt-compiler/src/wt_compiler/wizard/abstract.py
@@ -79,6 +79,10 @@ class LoopContext(TypedDict):
     """Zero-indexed iteration counter. ``0`` on first entry, increments each
     time the loop body completes and the first sub-question is re-yielded."""
 
+    label: str
+    """Singular display label used in confirm prompts (e.g. ``"requirement"``).
+    Defaults to ``dest`` when not explicitly set on the loop."""
+
 
 class SingleWizardQuestion(TypedDict):
     """A single question yielded by the wizard."""
@@ -106,6 +110,7 @@ class WizardQuestionLoop(TypedDict, total=False):
     argparse: ArgparseKwargs
     questions: list[WizardQuestion]  # pyright: ignore[reportGeneralTypeIssues]  # Required
     condition: Callable[[MappingProxyType[str, Any]], bool]
+    label: str
 
 
 WizardQuestion = SingleWizardQuestion | WizardQuestionLoop
@@ -301,7 +306,11 @@ class AbstractWizardProvider(ABC):
                 argparse=first_q["argparse"],
                 wizard=WizardKwargs(
                     **first_q.get("wizard", {}),
-                    loop_context=LoopContext(dest=question["dest"], iteration=iteration),
+                    loop_context=LoopContext(
+                        dest=question["dest"],
+                        iteration=iteration,
+                        label=question.get("label", question["dest"]),
+                    ),
                 ),
             )
             answer = yield first_q_with_ctx
@@ -325,7 +334,11 @@ class AbstractWizardProvider(ABC):
                     argparse=first_q["argparse"],
                     wizard=WizardKwargs(
                         **first_q.get("wizard", {}),
-                        loop_context=LoopContext(dest=question["dest"], iteration=iteration),
+                        loop_context=LoopContext(
+                            dest=question["dest"],
+                            iteration=iteration,
+                            label=question.get("label", question["dest"]),
+                        ),
                     ),
                 )
                 answer = yield first_q_with_ctx  # re-yield first question for next iteration

--- a/wt-compiler/src/wt_compiler/wizard/default.py
+++ b/wt-compiler/src/wt_compiler/wizard/default.py
@@ -538,6 +538,7 @@ _Q_REQUIREMENTS_LOOP_QUESTIONS: list[WizardQuestion] = [
 
 _Q_REQUIREMENTS = WizardQuestionLoop(
     dest="requirements",
+    label="requirement",
     argparse=ArgparseKwargs(
         action="append",
         default=None,


### PR DESCRIPTION
## :earth_americas: Summary
Closes #116

## :package: Proposed Changes
- Adds a `label` field to `WizardQuestionLoop`
- Updates the Requirements question loop in `DefaultWizardProvider` do use this new field

Visually, this is the difference between "Add a requirement?" (new) and "Add a requirements?" (old)
