### PR TITLE
Remove `pixi.lock` from Wizard Provider template

### DIFF
--- a/wt-compiler/src/wt_compiler/wizard/templates/.gitignore.jinja2
+++ b/wt-compiler/src/wt_compiler/wizard/templates/.gitignore.jinja2
@@ -12,7 +12,29 @@ venv/
 
 # Pixi
 .pixi/
-pixi.lock
 
 # CI
 .wt-tmp/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cython debug symbols
+cython_debug/
+
+.vscode
+.claude


### PR DESCRIPTION
## :earth_americas: Summary
Closes #100 

## :package: Proposed Changes
Removes pixi.lock from Wizard Provider's .gitignore template and adds some extra ignores
