### PR TITLE
Fix shallow copy in KnownTask.parameters_jsonschema

### DIFF
--- a/wt-compiler/src/wt_compiler/spec.py
+++ b/wt-compiler/src/wt_compiler/spec.py
@@ -5,6 +5,7 @@ the workflow specification (spec.yaml) input format.
 """
 
 import builtins
+import copy
 import hashlib
 import keyword
 import os
@@ -100,7 +101,7 @@ class KnownTask(BaseModel):
             >>> "y" in schema["properties"]
             False
         """
-        schema = self.json_schema.copy()
+        schema = copy.deepcopy(self.json_schema)
 
         # Add description if available
         if self.description and "description" not in schema:

--- a/wt-compiler/tests/test_spec.py
+++ b/wt-compiler/tests/test_spec.py
@@ -101,6 +101,34 @@ class TestKnownTask:
         assert "x" in schema["properties"]
 
 
+    def test_parameters_jsonschema_returns_independent_copies(self):
+        """Test that multiple calls return independent dicts, not shared references.
+
+        When two task instances share the same KnownTask (e.g., maybe_skip_df used
+        by both skip_map_generation and skip_attachment_download), mutations to one
+        schema must not affect the other. Regression test for #128.
+        """
+        task = KnownTask(
+            importable_reference="mod.maybe_skip_df",
+            json_schema={
+                "properties": {
+                    "skip": {"type": "boolean", "default": False, "description": "original"},
+                },
+            },
+        )
+
+        schema1 = task.parameters_jsonschema()
+        schema2 = task.parameters_jsonschema()
+
+        # Mutate schema1's nested property
+        schema1["properties"]["skip"]["default"] = True
+        schema1["properties"]["skip"]["description"] = "mutated"
+
+        # schema2 must be unaffected
+        assert schema2["properties"]["skip"]["default"] is False
+        assert schema2["properties"]["skip"]["description"] == "original"
+
+
 class TestKnownTaskSerialization:
     """Tests for KnownTask.serialize_importable_reference field serializer."""
 


### PR DESCRIPTION
## Summary
- Replace `dict.copy()` with `copy.deepcopy()` in `KnownTask.parameters_jsonschema()` so nested schema dicts aren't shared between task instances

## Problem
When two task instances use the same task (e.g., `maybe_skip_df`), they share the same `KnownTask.json_schema` dict. The shallow copy means RJSF overrides applied to one instance mutate shared nested dicts, causing overrides to bleed into other instances.

Fixes #128

## Test plan
- [x] Verified in `wt-download-events`: `skip_map_generation` and `skip_attachment_download` both use `maybe_skip_df`. Before fix, both get `default: true` and the attachment description. After fix, each retains its own overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)