### PR TITLE
fix: emit extras in to_pip_install_arg for local paths

### DIFF
--- a/docs/content/reference/spec-yaml.md
+++ b/docs/content/reference/spec-yaml.md
@@ -94,6 +94,23 @@ requirements:
     editable: true
 ```
 
+**Local ecoscope with extras** — for developing against a local checkout of
+the `ecoscope` package. Note: the conda package name is `ecoscope-platform`,
+but the PyPI/local package name is `ecoscope` with extras:
+
+```yaml
+requirements:
+  - name: python
+    version: "3.12.*"
+  - name: ecoscope
+    path: /Users/me/ecoscope
+    editable: true
+    extras: ["platform", "mapping", "analysis"]
+```
+
+The `python` version pin ensures the ephemeral discovery environment uses a
+Python version compatible with all transitive dependencies.
+
 **Git repository:**
 
 ```yaml

--- a/docs/content/reference/spec-yaml.md
+++ b/docs/content/reference/spec-yaml.md
@@ -125,11 +125,21 @@ Notes:
   - `platform`: pandera, pydantic, wt-registry, wt-task
   - `mapping`: lonboard, matplotlib (results/map tasks)
   - `analysis`: statsmodels (analysis tasks)
+- **Post-compile numpy patch** — ecoscope currently pins `numpy>=2,<2.1`,
+  which conflicts with what conda resolves on some platforms. After compiling,
+  manually edit the generated `pixi.toml` to pin `numpy>=2,<2.1` to match.
+  This constraint will be relaxed in a future ecoscope release.
 - **Post-compile pydantic patch** — ecoscope requires `pydantic<2.9.0` (newer
   versions break discriminated unions in `apply_classification`), but the
   compiler emits `pydantic>=2.0.0,<3.0.0` as a conda dependency. After
   compiling, manually edit the generated `pixi.toml` to pin
   `pydantic>=2.0.0,<2.9.0`.
+- **`wt_env` limitation** — `wt-compiler` requires `pydantic>=2.9` while
+  `ecoscope[platform]` requires `pydantic<2.9.0`. They cannot coexist in the
+  same pixi environment. Do not add the `platform` extra to ecoscope in the
+  `wt_env` feature of `environment-setup/pixi.toml`. The compiler does not
+  import ecoscope at runtime — it installs it in an ephemeral subprocess
+  environment for task discovery.
 
 **Git repository:**
 

--- a/docs/content/reference/spec-yaml.md
+++ b/docs/content/reference/spec-yaml.md
@@ -134,10 +134,9 @@ Notes:
   compiler emits `pydantic>=2.0.0,<3.0.0` as a conda dependency. After
   compiling, manually edit the generated `pixi.toml` to pin
   `pydantic>=2.0.0,<2.9.0`.
-- **`wt_env` limitation** — `wt-compiler` requires `pydantic>=2.9` while
+- **Separate environment limitation** — `wt-compiler` requires `pydantic>=2.9` while
   `ecoscope[platform]` requires `pydantic<2.9.0`. They cannot coexist in the
-  same pixi environment. Do not add the `platform` extra to ecoscope in the
-  `wt_env` feature of `environment-setup/pixi.toml`. The compiler does not
+  same pixi environment. Luckly, the compiler does not
   import ecoscope at runtime — it installs it in an ephemeral subprocess
   environment for task discovery.
 

--- a/docs/content/reference/spec-yaml.md
+++ b/docs/content/reference/spec-yaml.md
@@ -94,49 +94,6 @@ requirements:
     editable: true
 ```
 
-**Local ecoscope with extras** — for developing against a local checkout of
-the `ecoscope` package. The conda package name is `ecoscope-platform`, but
-the PyPI/local package name is `ecoscope` with extras:
-
-```yaml
-requirements:
-  - name: python
-    version: "3.12.*"
-  - name: rasterio
-    version: "1.5.0"
-    channel: conda-forge
-  - name: ecoscope
-    path: /Users/me/ecoscope
-    editable: true
-    extras: ["platform", "mapping", "analysis"]
-```
-
-Notes:
-
-- **`python` pin** — without this, the ephemeral discovery environment may
-  resolve Python 3.14+, where transitive deps like `pydantic-core` lack
-  pre-built wheels.
-- **`rasterio` conda dep** — ensures GDAL native libraries are available for
-  the editable ecoscope install.
-- **`extras`** — all three are required for task discovery to succeed:
-  - `platform`: pandera, pydantic, wt-registry, wt-task
-  - `mapping`: lonboard, matplotlib (results/map tasks)
-  - `analysis`: statsmodels (analysis tasks)
-- **Post-compile numpy patch** — ecoscope currently pins `numpy>=2,<2.1`,
-  which conflicts with what conda resolves on some platforms. After compiling,
-  manually edit the generated `pixi.toml` to pin `numpy>=2,<2.1` to match.
-  This constraint will be relaxed in a future ecoscope release.
-- **Post-compile pydantic patch** — ecoscope requires `pydantic<2.9.0` (newer
-  versions break discriminated unions in `apply_classification`), but the
-  compiler emits `pydantic>=2.0.0,<3.0.0` as a conda dependency. After
-  compiling, manually edit the generated `pixi.toml` to pin
-  `pydantic>=2.0.0,<2.9.0`.
-- **Separate environment limitation** — `wt-compiler` requires `pydantic>=2.9` while
-  `ecoscope[platform]` requires `pydantic<2.9.0`. They cannot coexist in the
-  same pixi environment. Luckly, the compiler does not
-  import ecoscope at runtime — it installs it in an ephemeral subprocess
-  environment for task discovery.
-
 **Git repository:**
 
 ```yaml

--- a/docs/content/reference/spec-yaml.md
+++ b/docs/content/reference/spec-yaml.md
@@ -109,9 +109,6 @@ requirements:
     path: /Users/me/ecoscope
     editable: true
     extras: ["platform", "mapping", "analysis"]
-  - name: ecoscope-workflows-ext-custom
-    path: /Users/me/ecoscope-workflow-task-library/src/ecoscope-workflows-ext-custom
-    editable: true
 ```
 
 Notes:

--- a/docs/content/reference/spec-yaml.md
+++ b/docs/content/reference/spec-yaml.md
@@ -95,21 +95,41 @@ requirements:
 ```
 
 **Local ecoscope with extras** — for developing against a local checkout of
-the `ecoscope` package. Note: the conda package name is `ecoscope-platform`,
-but the PyPI/local package name is `ecoscope` with extras:
+the `ecoscope` package. The conda package name is `ecoscope-platform`, but
+the PyPI/local package name is `ecoscope` with extras:
 
 ```yaml
 requirements:
   - name: python
     version: "3.12.*"
+  - name: rasterio
+    version: "1.5.0"
+    channel: conda-forge
   - name: ecoscope
     path: /Users/me/ecoscope
     editable: true
     extras: ["platform", "mapping", "analysis"]
+  - name: ecoscope-workflows-ext-custom
+    path: /Users/me/ecoscope-workflow-task-library/src/ecoscope-workflows-ext-custom
+    editable: true
 ```
 
-The `python` version pin ensures the ephemeral discovery environment uses a
-Python version compatible with all transitive dependencies.
+Notes:
+
+- **`python` pin** — without this, the ephemeral discovery environment may
+  resolve Python 3.14+, where transitive deps like `pydantic-core` lack
+  pre-built wheels.
+- **`rasterio` conda dep** — ensures GDAL native libraries are available for
+  the editable ecoscope install.
+- **`extras`** — all three are required for task discovery to succeed:
+  - `platform`: pandera, pydantic, wt-registry, wt-task
+  - `mapping`: lonboard, matplotlib (results/map tasks)
+  - `analysis`: statsmodels (analysis tasks)
+- **Post-compile pydantic patch** — ecoscope requires `pydantic<2.9.0` (newer
+  versions break discriminated unions in `apply_classification`), but the
+  compiler emits `pydantic>=2.0.0,<3.0.0` as a conda dependency. After
+  compiling, manually edit the generated `pixi.toml` to pin
+  `pydantic>=2.0.0,<2.9.0`.
 
 **Git repository:**
 

--- a/wt-compiler/src/wt_compiler/spec.py
+++ b/wt-compiler/src/wt_compiler/spec.py
@@ -999,9 +999,10 @@ class PyPIRequirement(_ForbidExtra):
             extras = f"[{','.join(self.extras)}]" if self.extras else ""
             return f"{self.name}{extras} @ {arg}"
         elif self.path is not None:
+            extras = f"[{','.join(self.extras)}]" if self.extras else ""
             if self.editable:
-                return f"-e {self.path}"
-            return self.path
+                return f"-e {self.path}{extras}"
+            return f"{self.path}{extras}"
         elif self.url is not None:
             extras = f"[{','.join(self.extras)}]" if self.extras else ""
             return f"{self.name}{extras} @ {self.url}"

--- a/wt-compiler/tests/test_spec.py
+++ b/wt-compiler/tests/test_spec.py
@@ -414,6 +414,18 @@ class TestPyPIRequirement:
         req = PyPIRequirement(name="foo", path="/opt/foo", editable=True)
         assert req.to_pip_install_arg() == "-e /opt/foo"
 
+    def test_to_pip_install_arg_path_with_extras(self):
+        """Test pip install arg for path requirement with extras."""
+        req = PyPIRequirement(name="foo", path="/opt/foo", extras=["platform"])
+        assert req.to_pip_install_arg() == "/opt/foo[platform]"
+
+    def test_to_pip_install_arg_path_editable_with_extras(self):
+        """Test pip install arg for editable path requirement with extras."""
+        req = PyPIRequirement(
+            name="foo", path="/opt/foo", editable=True, extras=["platform", "dev"]
+        )
+        assert req.to_pip_install_arg() == "-e /opt/foo[platform,dev]"
+
     def test_to_pip_install_arg_url(self):
         """Test pip install arg for URL requirement."""
         req = PyPIRequirement(name="foo", url="https://example.com/foo-1.0.whl")


### PR DESCRIPTION
## Summary
- `PyPIRequirement.to_pip_install_arg()` was not emitting `extras` for local path requirements (both editable and non-editable)
- This caused compilation failures when a spec declared a local path with extras (e.g., `ecoscope[platform]`), since required dependencies were missing from the ephemeral environment
- Added two test cases covering path + extras for both editable and non-editable variants

Closes #133

🤖 Generated with Claude Code