### PR TITLE
fix: resolve nested partial refs in VariableValuesDict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ __marimo__/
 
 
 .vscode
+.DS_Store
 
 # generated outputs from our docs examples
 docs/examples/**/wt-*-workflow

--- a/wt-compiler/src/wt_compiler/spec.py
+++ b/wt-compiler/src/wt_compiler/spec.py
@@ -271,7 +271,11 @@ class SerializedVariableValuesDict(TypedDict):
     """Serialized shape of a VariableValuesDict."""
 
     asstr: str
-    asdict: dict[str, "SerializedInlineValue | SerializedVars"]
+    asdict: dict[
+        str,
+        "SerializedInlineValue | SerializedVars"
+        " | SerializedVariableValuesDict | SerializedVariableValuesList",
+    ]
     has_variable_values: bool
 
 

--- a/wt-compiler/src/wt_compiler/spec.py
+++ b/wt-compiler/src/wt_compiler/spec.py
@@ -477,7 +477,9 @@ class VariableValuesDict(BaseModel):
                 )
                 + "}"
             ),
-            "asdict": ({k: _serialize_dict_or_variables_or_inline_value(v) for k, v in self.value.items()}),
+            "asdict": (
+                {k: _serialize_dict_or_variables_or_inline_value(v) for k, v in self.value.items()}
+            ),
             "has_variable_values": True,
         }
 

--- a/wt-compiler/src/wt_compiler/spec.py
+++ b/wt-compiler/src/wt_compiler/spec.py
@@ -463,7 +463,7 @@ VarsOrInlineValue = Annotated[
 class VariableValuesDict(BaseModel):
     """A dictionary with variable values."""
 
-    value: dict[str, VarsOrInlineValue]
+    value: dict[str, "DictOrVarsOrInlineValue"]
 
     @model_serializer
     def serialize(self) -> SerializedVariableValuesDict:
@@ -472,12 +472,12 @@ class VariableValuesDict(BaseModel):
             "asstr": (
                 "{"
                 + ", ".join(
-                    f"'{k}': {_serialize_variables_or_inline_value(v).get('asstr')}"
+                    f"'{k}': {_serialize_dict_or_variables_or_inline_value(v).get('asstr')}"
                     for k, v in self.value.items()
                 )
                 + "}"
             ),
-            "asdict": ({k: _serialize_variables_or_inline_value(v) for k, v in self.value.items()}),
+            "asdict": ({k: _serialize_dict_or_variables_or_inline_value(v) for k, v in self.value.items()}),
             "has_variable_values": True,
         }
 

--- a/wt-compiler/src/wt_compiler/templates/pkg/dags/_macros.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/pkg/dags/_macros.jinja2
@@ -62,33 +62,53 @@ task({{ t.known_task.importable_reference.function }})
 {% endmacro %}
 
 
-{% macro handle_async_partial_arg_aslist(aslist) %}[
-                    {% for v in aslist %}
-                    {% if v["is_inline_value"] %}
-                    {{ v["asstr"] }},
-                    {% elif v["has_variable_values"] %}
-                    {{ v["asstr"] }},
-                    {% else %}
-                    {% if "os.environ" in v["asstr"] %}
-                    {{ v["aslist"][0] }},
-                    {% else %}
-                    DependsOn("{{ v["aslist"][0] }}"),
-                    {% endif %}
-                    {% endif %}
-                    {% endfor %}
-                ]{% endmacro %}
+{% macro handle_async_partial_arg_aslist(value) %}
+    {% if value["has_variable_values"] %}
+    {% if value["aslist"] %}
+    [
+        {% for inner in value["aslist"] %}
+        {{ handle_async_partial_arg_aslist(inner) }}
+        {% endfor %}
+    ],
+    {% endif %}
+    {% if value["asdict"] %}
+    {
+    {% for nested_arg, nested_value in value["asdict"].items() %}
+    {{ handle_async_partial_arg(nested_arg, nested_value) }}
+    {% endfor %}
+    },
+    {% endif %}
+    {% endif %}
+
+    {% if value["is_inline_value"] %}
+    {{ value["asstr"] }},
+    {% endif %}
+
+    {% if not value["has_variable_values"] and not value["is_inline_value"] %}
+    {% if "os.environ" in value["asstr"] %}
+    {{ value["aslist"][0] }},
+    {% else %}
+    DependsOn("{{ value["aslist"][0] }}"),
+    {% endif %}
+    {% endif %}
+{% endmacro %}
 
 
 {% macro handle_async_partial_arg(arg, value) %}
     {% if value["has_variable_values"] %}
+    {% if value["aslist"] %}
+    "{{ arg }}": [
+        {% for inner in value["aslist"] %}
+        {{ handle_async_partial_arg_aslist(inner) }}
+        {% endfor %}
+    ],
+    {% endif %}
     {% if value["asdict"] %}
     "{{ arg }}": {
-        {% for nested_arg, nested_value in value["asdict"].items() %}
-        {{ handle_async_partial_arg(nested_arg, nested_value) }}
-        {% endfor %}
+    {% for nested_arg, nested_value in value["asdict"].items() %}
+    {{ handle_async_partial_arg(nested_arg, nested_value) }}
+    {% endfor %}
     },
-    {% elif value["aslist"] %}
-    "{{ arg }}": {{ handle_async_partial_arg_aslist(value["aslist"]) }},
     {% endif %}
     {% elif value["is_inline_value"] %}
     "{{ arg }}": {{ value["asstr"] }},

--- a/wt-compiler/tests/test_spec.py
+++ b/wt-compiler/tests/test_spec.py
@@ -873,7 +873,7 @@ class TestVariableValuesDict:
             known_tasks.clear()
 
     def test_variable_ref_in_dict_in_list_in_dict(self):
-        """Test ${{ }} ref inside dict → list → dict nesting (the create_docx pattern)."""
+        """Test ${{ }} ref inside dict → list → dict nesting."""
         from wt_compiler.spec import known_tasks
 
         mock_task = KnownTask(importable_reference="mod.func")

--- a/wt-compiler/tests/test_spec.py
+++ b/wt-compiler/tests/test_spec.py
@@ -14,6 +14,7 @@ from wt_compiler.spec import (
     TaskIdVariable,
     TaskInstance,
     TaskTag,
+    VariableValuesDict,
     VariableValuesList,
     _conda_or_pypi,
     _find_task_id_vars,
@@ -836,6 +837,111 @@ class TestFindTaskIdVars:
         assert len(result) == 2
         assert result[0].value == "task1"
         assert result[1].value == "task2"
+
+
+class TestVariableValuesDict:
+    """Tests for VariableValuesDict with nested dicts and lists containing variable refs."""
+
+    def test_nested_dict_with_variable_ref(self):
+        """Test that a variable ref inside a nested dict is parsed as TaskIdVariable."""
+        from wt_compiler.spec import known_tasks
+
+        mock_task = KnownTask(importable_reference="mod.func")
+        known_tasks["func"] = {"mod": mock_task}
+
+        try:
+            ti = TaskInstance(
+                id="task2",
+                name="Nested Dict Task",
+                task="mod.func",
+                partial={
+                    "context": {
+                        "key": "value",
+                        "ref": "${{ workflow.task1.return }}",
+                    }
+                },
+            )
+            dep = ti.partial["context"]
+            assert isinstance(dep, VariableValuesDict)
+            serialized = ti.model_dump()
+            context = serialized["partial"]["context"]
+            assert context["has_variable_values"] is True
+            assert "task1" in context["asstr"]
+            assert "'ref': task1" in context["asstr"]
+            assert "'key': 'value'" in context["asstr"]
+        finally:
+            known_tasks.clear()
+
+    def test_variable_ref_in_dict_in_list_in_dict(self):
+        """Test ${{ }} ref inside dict → list → dict nesting (the create_docx pattern)."""
+        from wt_compiler.spec import known_tasks
+
+        mock_task = KnownTask(importable_reference="mod.func")
+        known_tasks["func"] = {"mod": mock_task}
+
+        try:
+            ti = TaskInstance(
+                id="report_task",
+                name="Report Task",
+                task="mod.func",
+                partial={
+                    "context": {
+                        "items": [
+                            {
+                                "item_type": "timerange",
+                                "key": "report_date",
+                                "value": "${{ workflow.time_range.return }}",
+                            },
+                            {
+                                "item_type": "table",
+                                "key": "stats",
+                                "value": "${{ workflow.stats_sql.return }}",
+                            },
+                        ]
+                    }
+                },
+            )
+            serialized = ti.model_dump()
+            context = serialized["partial"]["context"]
+            assert context["has_variable_values"] is True
+            # The asstr should contain resolved variable names, not ${{ }} strings
+            assert "time_range" in context["asstr"]
+            assert "stats_sql" in context["asstr"]
+            assert "${{" not in context["asstr"]
+        finally:
+            known_tasks.clear()
+
+    def test_nested_variable_ref_in_asdict(self):
+        """Test that asdict contains properly serialized nested variable refs."""
+        from wt_compiler.spec import known_tasks
+
+        mock_task = KnownTask(importable_reference="mod.func")
+        known_tasks["func"] = {"mod": mock_task}
+
+        try:
+            ti = TaskInstance(
+                id="task2",
+                name="Nested Task",
+                task="mod.func",
+                partial={
+                    "outer": {
+                        "inner_list": [
+                            {"ref": "${{ workflow.task1.return }}", "literal": "hello"},
+                        ]
+                    }
+                },
+            )
+            serialized = ti.model_dump()
+            outer = serialized["partial"]["outer"]
+            # Walk into asdict → inner_list → aslist → first item → asdict → ref
+            inner_list = outer["asdict"]["inner_list"]
+            assert inner_list["has_variable_values"] is True
+            first_item = inner_list["aslist"][0]
+            assert first_item["has_variable_values"] is True
+            ref_val = first_item["asdict"]["ref"]
+            assert ref_val["asstr"] == "task1"
+        finally:
+            known_tasks.clear()
 
 
 class TestSpec:


### PR DESCRIPTION
Closes #141

## Summary
- Fixed `VariableValuesDict.value` type from `dict[str, VarsOrInlineValue]` to `dict[str, DictOrVarsOrInlineValue]` to support nested dicts/lists containing `${{ }}` refs
- Updated serialization to use recursive `_serialize_dict_or_variables_or_inline_value` 
- Fixed async template macros to recursively process nested structures (matching ecoscope-workflows reference)

**Root cause:** When `partial` contained deeply nested structures (dict → list → dict `${{ }}`), the refs were emitted as literal strings instead of resolved Python variable names.

**Use case:** `create_docx` task's `context.items` parameter, where each item's `value` field references other task outputs.

## Test plan
- [x] Added 3 unit tests in `test_spec.py::TestVariableValuesDict`
- [x] All 80 existing tests pass
- [x] End-to-end: compile encounter-rate workflow with nested `create_docx` refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)