### PR TITLE
Support custom network settings in CloudBatchInvoker

### DIFF
--- a/wt-invokers/src/wt_invokers/cloud_batch.py
+++ b/wt-invokers/src/wt_invokers/cloud_batch.py
@@ -192,6 +192,12 @@ class CloudBatchInvoker(AbstractInvoker):
                 - timeout: Optional timeout in seconds
                 - gpu_type: Optional GPU type
                 - gpu_count: Optional GPU count (default: 1)
+                - network: GCP VPC network resource path
+                    (e.g. projects/<project>/global/networks/<vpc>)
+                - subnetwork: GCP subnetwork resource path
+                    (e.g. projects/<project>/regions/<region>/subnetworks/<subnet>)
+                - no_external_ip: When True, VMs get no external IP and
+                    egress via Cloud NAT (default: False)
 
         Raises:
             ValueError: If docker_image_uri or workflow_run_id is missing
@@ -339,6 +345,9 @@ class CloudBatchInvoker(AbstractInvoker):
                 - timeout: Optional timeout in seconds
                 - gpu_type: Optional GPU type
                 - gpu_count: Optional GPU count
+                - network: GCP VPC network resource path
+                - subnetwork: GCP subnetwork resource path
+                - no_external_ip: When True, VMs get no external IP
 
         Returns:
             Created Cloud Batch Job object
@@ -396,6 +405,19 @@ class CloudBatchInvoker(AbstractInvoker):
         instances.policy = policy
         allocation_policy = AllocationPolicy()
         allocation_policy.instances = [instances]
+
+        # Route batch VMs through a specific VPC so they egress via Cloud NAT
+        # instead of getting a random external IP.
+        if network := kwargs.get("network"):
+            network_interface = AllocationPolicy.NetworkInterface()
+            network_interface.network = network
+            network_interface.subnetwork = kwargs.get("subnetwork", "")
+            network_interface.no_external_ip_address = bool(
+                kwargs.get("no_external_ip", False)
+            )
+            network_policy = AllocationPolicy.NetworkPolicy()
+            network_policy.network_interfaces = [network_interface]
+            allocation_policy.network = network_policy
 
         # Use a different service account if specified
         if batch_service_account_email := os.getenv("BATCH_SERVICE_ACCOUNT"):

--- a/wt-invokers/tests/test_cloud_batch.py
+++ b/wt-invokers/tests/test_cloud_batch.py
@@ -415,3 +415,68 @@ async def test_create_container_job_with_gpu(mock_gcp_modules) -> None:
         )
 
         assert result == mock_job
+
+
+@pytest.mark.asyncio
+async def test_create_container_job_with_vpc_network(mock_gcp_modules) -> None:
+    """Test _create_container_job configures VPC network."""
+    from wt_invokers.cloud_batch import CloudBatchInvoker
+
+    matchspec = MatchSpec("test-workflow>=1.0.0")
+    invoker = CloudBatchInvoker(matchspec=matchspec)
+
+    mock_client = MagicMock()
+    mock_job = MagicMock()
+    mock_client.create_job.return_value = mock_job
+    mock_gcp_modules.BatchServiceClient.return_value = mock_client
+
+    vpc_network = "projects/my-project/global/networks/my-vpc"
+    vpc_subnetwork = "projects/my-project/regions/us-west2/subnetworks/cloud-batch"
+
+    with patch("asyncio.to_thread", new=AsyncMock(return_value=mock_job)):
+        result = await invoker._create_container_job(
+            job_name="test-job",
+            docker_image_uri="gcr.io/project/image:latest",
+            cmd=["pixi", "run", "workflow"],
+            network=vpc_network,
+            subnetwork=vpc_subnetwork,
+            no_external_ip=True,
+        )
+
+        assert result == mock_job
+
+    mock_gcp_modules.AllocationPolicy.NetworkInterface.assert_called_once_with()
+    net_iface = mock_gcp_modules.AllocationPolicy.NetworkInterface.return_value
+    assert net_iface.network == vpc_network
+    assert net_iface.subnetwork == vpc_subnetwork
+    assert net_iface.no_external_ip_address is True
+
+    mock_gcp_modules.AllocationPolicy.NetworkPolicy.assert_called_once_with()
+    net_policy = mock_gcp_modules.AllocationPolicy.NetworkPolicy.return_value
+    assert net_policy.network_interfaces == [net_iface]
+
+
+@pytest.mark.asyncio
+async def test_create_container_job_without_vpc_network(mock_gcp_modules) -> None:
+    """Test _create_container_job skips VPC config when absent."""
+    from wt_invokers.cloud_batch import CloudBatchInvoker
+
+    matchspec = MatchSpec("test-workflow>=1.0.0")
+    invoker = CloudBatchInvoker(matchspec=matchspec)
+
+    mock_client = MagicMock()
+    mock_job = MagicMock()
+    mock_client.create_job.return_value = mock_job
+    mock_gcp_modules.BatchServiceClient.return_value = mock_client
+
+    with patch("asyncio.to_thread", new=AsyncMock(return_value=mock_job)):
+        result = await invoker._create_container_job(
+            job_name="test-job",
+            docker_image_uri="gcr.io/project/image:latest",
+            cmd=["pixi", "run", "workflow"],
+        )
+
+        assert result == mock_job
+
+    mock_gcp_modules.AllocationPolicy.NetworkInterface.assert_not_called()
+    mock_gcp_modules.AllocationPolicy.NetworkPolicy.assert_not_called()


### PR DESCRIPTION
## :earth_americas: Summary
Closes #139

## :package: Proposed Changes
Update the `CloudBatchInvoker` to support custom network settings as needed when using the DWH API
