### PR TITLE
Update CHANGELOGs for release 2026-04-28

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1 — 2026-04-28
+
+- Fix `PyPIRequirement.to_pip_install_arg()` to emit extras for local path requirements, both editable and non-editable ([#137](https://github.com/wildlife-dynamics/wt/pull/137))
+
 ## v0.5.0 — 2026-04-14
 
 - Fix shallow copy in `KnownTask.parameters_jsonschema` to prevent schema mutation across task uses ([#129](https://github.com/wildlife-dynamics/wt/pull/129))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -112,7 +112,7 @@ ignore = []
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers-gcp/CHANGELOG.md
+++ b/wt-invokers-gcp/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## v0.2.0 — 2026-04-28
+
+- Lockstep release with wt-invokers v0.2.0

--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -32,7 +32,7 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.1.2"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0 — 2026-04-28
+
+- Add optional `network`, `subnetwork`, and `no_external_ip` kwargs to `CloudBatchInvoker` for routing batch VMs through a specific VPC and egressing via Cloud NAT ([#143](https://github.com/wildlife-dynamics/wt/pull/143))
+
 ## v0.1.2 — 2026-03-13
 
 - Bootstrap release for prefix.dev conda channel

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -144,7 +144,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.1.2"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

closes #147

Release prep for 2026-04-28:

- **wt-compiler** 0.5.0 → 0.5.1 — Fix `PyPIRequirement.to_pip_install_arg()` to emit extras for local path requirements (#137)
- **wt-invokers** 0.1.2 → 0.2.0 — Add `network`, `subnetwork`, `no_external_ip` kwargs to `CloudBatchInvoker` for VPC routing via Cloud NAT (#143)
- **wt-invokers-gcp** 0.1.2 → 0.2.0 — Lockstep release with wt-invokers

## Test plan

- [ ] CI passes on this branch
- [ ] Merge, then tag and push (parent then GCP metapackage) per release runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)