### PR TITLE
Update CHANGELOGs for release 2026-04-29

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.2 — 2026-04-29
+
+- Fix `VariableValuesDict` to resolve `${{ ... }}` refs inside nested partial arguments (dict-in-dict, dict-in-list, list-in-dict); rewrites the `handle_async_partial_arg` Jinja macros to recurse through nested structures ([#140](https://github.com/wildlife-dynamics/wt/pull/140))
+
 ## v0.5.1 — 2026-04-28
 
 - Fix `PyPIRequirement.to_pip_install_arg()` to emit extras for local path requirements, both editable and non-editable ([#137](https://github.com/wildlife-dynamics/wt/pull/137))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -112,7 +112,7 @@ ignore = []
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.5.1"
+version = "0.5.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

closes #148

- Bump `wt-compiler` to **v0.5.2** (patch): fix nested partial refs in `VariableValuesDict` ([#140](https://github.com/wildlife-dynamics/wt/pull/140))
- Prepend v0.5.2 entry to `wt-compiler/CHANGELOG.md`
- Bump `[tool.pixi.package] version` in `wt-compiler/pyproject.toml` to `0.5.2`

No other packages have changes since their last tags. Compiler lower-bound pins for `wt-task` and `wt-runner` already match current tags — no `compiler.py` update needed.

## Test plan

- [x] CI passes on the release branch
- [ ] After merge: tag `wt-compiler/v0.5.2` from `main` and push to trigger the publish workflow
- [ ] Verify `wt-compiler==0.5.2` is published to PyPI and the `ecoscope-workflows` channel on prefix.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)