### PR TITLE
Update CHANGELOGs for release 2026-05-13

### DIFF
--- a/.claude/commands/release-wt.md
+++ b/.claude/commands/release-wt.md
@@ -57,8 +57,9 @@ When wt-task or wt-runner are being released, their version lower bounds declare
 
 3. If any update is needed:
    a. Update the `>=X.Y.Z` portion of the `version` constraint in the relevant entry/entries in `default-env-injections.toml` to the new release version (preserve the existing `<1.0.0` upper bound)
-   b. If wt-compiler is **not** already in the release set, add it with a **patch bump** (reason: "Update wt-task/wt-runner version floors in default-env-injections.toml")
-   c. Present the changes (old → new lower bounds, wt-compiler version bump) and ask for confirmation
+   b. Update the matching pin in `wt-compiler/tests/test_default_env_injections.py` — the `EXPECTED_SPECS["default"]` entry for `wt-task` and/or the `EXPECTED_SPECS["runner"]` entry for `wt-runner` hardcode the expected lower bound and will fail in CI otherwise. Keep this in lockstep with the toml.
+   c. If wt-compiler is **not** already in the release set, add it with a **patch bump** (reason: "Update wt-task/wt-runner version floors in default-env-injections.toml")
+   d. Present the changes (old → new lower bounds, test-file updates, wt-compiler version bump) and ask for confirmation
 
 4. If no updates needed, report that and move on
 
@@ -82,7 +83,7 @@ For each package being released:
    ```
 4. Update `[tool.pixi.package] version` in each released package's `pyproject.toml` to match the new version. For GCP metapackages released in lockstep, update their `pyproject.toml` too.
 5. After preparing all CHANGELOG and pyproject.toml updates, ask the user for final confirmation before committing
-6. Commit **all** CHANGELOG, pyproject.toml, **and any default-env-injections.toml lower-bound** updates in a single commit (message: `Update CHANGELOGs and pixi versions for release`)
+6. Commit **all** CHANGELOG, pyproject.toml, **any default-env-injections.toml lower-bound, and any matching test_default_env_injections.py pin** updates in a single commit (message: `Update CHANGELOGs and pixi versions for release`)
 7. Push the release branch and create a PR to `main` via `gh pr create`. Include today's date in the PR title (e.g., `Update CHANGELOGs for release YYYY-MM-DD`) to avoid duplicate PR names across releases.
 8. Ask the user to merge the PR (branch protection requires a PR to update `main`)
 9. After the user confirms the PR is merged, checkout `main` and pull to get the merge commit — tags must point to commits on `main`

--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.6.0 — 2026-05-13
+
+- Pluggable environment injection: new `default-env-injections.toml` ships with the package as the baseline conda/pypi spec; spec `requirements:` entries suppress same-name baseline entries; user `--env-overrides` files take final precedence. New `env_overrides` and `pixi_toml_fragment` modules implement the layered merge ([#156](https://github.com/wildlife-dynamics/wt/pull/156))
+- Export `compute_merged_default_feature` from the top-level package ([#156](https://github.com/wildlife-dynamics/wt/pull/156))
+- Compiled workflow artifacts now include `pyproject.toml` and `hatch_build.py` so the templated package can be built as a wheel. `PackageDirectory` drops the standalone `params.py` / `formdata.py` artifact fields ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Add snapshot-update step to the generated `ci.yml` template; error on failed upload ([#162](https://github.com/wildlife-dynamics/wt/pull/162))
+- Fix deferred dispatcher imports ([#159](https://github.com/wildlife-dynamics/wt/pull/159))
+- Revert `to_windows_safe_path` ([#158](https://github.com/wildlife-dynamics/wt/pull/158))
+- Remove the standalone `pypi_source.py` module (functionality folded into the new env-injection layer) ([#156](https://github.com/wildlife-dynamics/wt/pull/156))
+- Standardize ruff lint config to enforce type annotations and Google-style docstrings ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+- Bump `wt-task` floor to `>=0.1.3` and `wt-runner` floor to `>=0.2.0` in `default-env-injections.toml` to match this release's downstream versions
+
 ## v0.5.2 — 2026-04-29
 
 - Fix `VariableValuesDict` to resolve `${{ ... }}` refs inside nested partial arguments (dict-in-dict, dict-in-list, list-in-dict); rewrites the `handle_async_partial_arg` Jinja macros to recurse through nested structures ([#140](https://github.com/wildlife-dynamics/wt/pull/140))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -156,7 +156,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.5.2"
+version = "0.6.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-compiler/src/wt_compiler/default-env-injections.toml
+++ b/wt-compiler/src/wt_compiler/default-env-injections.toml
@@ -21,10 +21,10 @@ pydantic          = { version = ">=2.0.0,<3.0.0",  channel = "conda-forge" }
 # YAML round-trips when dumper/loader envs land on different parsers.
 "ruamel.yaml"     = { version = ">=0.18.0,<0.19.0", channel = "conda-forge" }
 opentelemetry-api = { version = ">=1.20.0,<2.0.0", channel = "conda-forge" }
-wt-task           = { version = ">=0.1.2,<1.0.0",  channel = "ecoscope-workflows" }
+wt-task           = { version = ">=0.1.3,<1.0.0",  channel = "ecoscope-workflows" }
 
 [feature.runner.dependencies]
-wt-runner = { version = ">=0.1.5,<1.0.0", channel = "ecoscope-workflows" }
+wt-runner = { version = ">=0.2.0,<1.0.0", channel = "ecoscope-workflows" }
 
 [feature.test.dependencies]
 pandas         = { version = "*",        channel = "conda-forge" }

--- a/wt-compiler/tests/test_default_env_injections.py
+++ b/wt-compiler/tests/test_default_env_injections.py
@@ -25,10 +25,10 @@ EXPECTED_SPECS = {
         ("pydantic", ">=2.0.0,<3.0.0", CONDA_FORGE_CHANNEL.base_url),
         ("ruamel.yaml", ">=0.18.0,<0.19.0", CONDA_FORGE_CHANNEL.base_url),
         ("opentelemetry-api", ">=1.20.0,<2.0.0", CONDA_FORGE_CHANNEL.base_url),
-        ("wt-task", ">=0.1.2,<1.0.0", RELEASE_CHANNEL.base_url),
+        ("wt-task", ">=0.1.3,<1.0.0", RELEASE_CHANNEL.base_url),
     ],
     "runner": [
-        ("wt-runner", ">=0.1.5,<1.0.0", RELEASE_CHANNEL.base_url),
+        ("wt-runner", ">=0.2.0,<1.0.0", RELEASE_CHANNEL.base_url),
     ],
     "test": [
         ("pandas", "*", CONDA_FORGE_CHANNEL.base_url),

--- a/wt-contracts/CHANGELOG.md
+++ b/wt-contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0 — 2026-05-13
+
+- Add `formdata` module: schema-driven conversion helpers `formdata_to_params` / `params_to_formdata`, a `validate` wrapper around `jsonschema.Draft202012Validator`, and `ValidationError` / `ValidationErrorResponse` / `ValidationErrorItem` Pydantic models for FastAPI/OpenAPI use ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Add `jsonschema>=4.0.0,<5.0.0` runtime dependency ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Standardize ruff lint config to enforce type annotations and Google-style docstrings ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.1.2 — 2026-03-13
 
 - Bootstrap release for prefix.dev conda channel

--- a/wt-contracts/pyproject.toml
+++ b/wt-contracts/pyproject.toml
@@ -143,7 +143,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-contracts"
-version = "0.1.2"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers-gcp/CHANGELOG.md
+++ b/wt-invokers-gcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.3.0 — 2026-05-13
+
+- Lockstep release with wt-invokers v0.3.0
+- Bump minimum Python to `>=3.12` (required by `google-cloud-run`)
+- Add `google-cloud-run>=0.10.0` for `CloudRunJobsSandboxInvoker` ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Adopt the standardized ruff lint config ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.2.0 — 2026-04-28
 
 - Lockstep release with wt-invokers v0.2.0

--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -92,7 +92,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.0 — 2026-05-13
+
+- Add `SandboxInvoker`: downloads a pixi-pack environment tarball, runs the workflow inside the unpacked env, and uploads a results archive to a signed URL. Exposed via the `wt-invokers.sandbox` console entry point as a Docker image ENTRYPOINT ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Add `CloudRunJobsSandboxInvoker`: proxy that triggers a pre-deployed Cloud Run Job whose container runs the sandbox CLI ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Refactor `AbstractInvoker.run()` / `wait()` into concrete lifecycle wrappers around `_pre_run` / `_run` / `_wait` / `_post_run` hooks, with an immutable `run_args` view and mutable `run_state` dict for hook-to-hook state sharing. Existing invokers internally renamed `run`→`_run` / `wait`→`_wait` — external call sites unchanged ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Add `PixiUnpackMixin` (`_pre_run` hook: stamina-retried environment download + pixi-unpack) and `UploadResultsArchiveMixin` (`_post_run` hook: stream-PUT tar of results to signed URL, or copy to `file://` for tests) ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Add `PixiUnpackError` wrapping `subprocess.CalledProcessError` with `returncode` / `stdout` / `stderr` ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Add `publish-docker` CI job that builds and pushes the sandbox image on `wt-invokers/v*` tags after the conda package is available on prefix.dev ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Standardize ruff lint config to enforce type annotations and Google-style docstrings ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.2.0 — 2026-04-28
 
 - Add optional `network`, `subnetwork`, and `no_external_ip` kwargs to `CloudBatchInvoker` for routing batch VMs through a specific VPC and egressing via Cloud NAT ([#143](https://github.com/wildlife-dynamics/wt/pull/143))

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -194,7 +194,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-registry/CHANGELOG.md
+++ b/wt-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2 — 2026-05-13
+
+- Standardize ruff lint config to enforce type annotations and Google-style docstrings; convert docstrings and example scripts accordingly ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.2.1 — 2026-04-14
 
 - Fix `SurfacesDescriptionSchema` to serialize `BaseModel` default values via `.model_dump()` instead of storing the raw model instance in the JSON schema

--- a/wt-registry/pyproject.toml
+++ b/wt-registry/pyproject.toml
@@ -149,7 +149,7 @@ files = ["src/wt_registry"]
 
 [tool.pixi.package]
 name = "wt-registry"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner-gcp/CHANGELOG.md
+++ b/wt-runner-gcp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0 — 2026-05-13
+
+- Lockstep release with wt-runner v0.2.0
+- Adopt the standardized ruff lint config ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.1.5 — 2026-03-27
 
 - Lockstep release with wt-runner v0.1.5

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -108,7 +108,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-runner-gcp"
-version = "0.1.5"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner/CHANGELOG.md
+++ b/wt-runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0 — 2026-05-13
+
+- Register the new `SandboxInvoker` and `CloudRunJobsSandboxInvoker` in the `INVOKERS` dispatch map ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Rewrite `_convert` to consume the compiled CLI's single-key envelope (`{"result": ...}` or `{"validation_errors": [...]}`), raising `wt_contracts.ValidationError` on schema-validation failure. Remove the obsolete `_is_422` helper ([#164](https://github.com/wildlife-dynamics/wt/pull/164))
+- Standardize ruff lint config to enforce type annotations and Google-style docstrings ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.1.5 — 2026-03-27
 
 - Fix errant injection of `wt-task` into the wt-runner conda environment

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -167,7 +167,7 @@ extend-immutable-calls = [
 
 [tool.pixi.package]
 name = "wt-runner"
-version = "0.1.5"
+version = "0.2.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-task-gcp/CHANGELOG.md
+++ b/wt-task-gcp/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog
+
+## v0.1.3 — 2026-05-13
+
+- Lockstep release with wt-task v0.1.3
+- Adopt the standardized ruff lint config ([#155](https://github.com/wildlife-dynamics/wt/pull/155))

--- a/wt-task-gcp/pyproject.toml
+++ b/wt-task-gcp/pyproject.toml
@@ -92,7 +92,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-task-gcp"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-task/CHANGELOG.md
+++ b/wt-task/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3 — 2026-05-13
+
+- Standardize ruff lint config to enforce type annotations and Google-style docstrings; convert module/class/function docstrings accordingly ([#155](https://github.com/wildlife-dynamics/wt/pull/155))
+
 ## v0.1.2 — 2026-03-13
 
 - `configure_tracer()` and `attach_context()` now warn instead of raising `ImportError` when tracing deps are missing ([#60](https://github.com/wildlife-dynamics/wt/pull/60))

--- a/wt-task/pyproject.toml
+++ b/wt-task/pyproject.toml
@@ -159,7 +159,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-task"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary

closes #171

Release bumps for 2026-05-13:

| Package | Current | New |
|---|---|---|
| wt-contracts | 0.1.2 | 0.2.0 |
| wt-registry | 0.2.1 | 0.2.2 |
| wt-task | 0.1.2 | 0.1.3 |
| wt-task-gcp | 0.1.2 | 0.1.3 |
| wt-compiler | 0.5.2 | 0.6.0 |
| wt-invokers | 0.2.0 | 0.3.0 |
| wt-invokers-gcp | 0.2.0 | 0.3.0 |
| wt-runner | 0.1.5 | 0.2.0 |
| wt-runner-gcp | 0.1.5 | 0.2.0 |

Also bumps the `wt-task` / `wt-runner` lower bounds in `wt-compiler/src/wt_compiler/default-env-injections.toml` to match.

See each package's CHANGELOG.md for details.

## Test plan

- [x] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)