### PR TITLE
revert(wt-compiler): drop rjsf-overrides $defs propagation to params.json

### DIFF
--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "wt-contracts>=0.1.0,<1.0.0",
+    "wt-contracts>=0.2.0,<1.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "jinja2>=3.0.0",
     "ruamel.yaml>=0.17.0,<0.19.0",  # <0.19.0 pin; xref src/wt_compiler/default-env-injections.toml for detail
@@ -43,6 +43,7 @@ dev = [
     "ruff>=0.1.0",
     "build>=1.0.0",
     "hatchling>=1.18.0",
+    "types-jsonschema",
 ]
 
 [dependency-groups]
@@ -54,6 +55,7 @@ dev = [
     "ruff>=0.1.0",
     "build>=1.0.0",
     "hatchling>=1.18.0",
+    "types-jsonschema",
 ]
 
 [tool.setuptools.packages.find]
@@ -179,5 +181,5 @@ py-rattler = ">=0.22.0,<0.23.0"
 pydot = ">=1.4.0"
 ruff = ">=0.1.0"
 tomli-w = ">=1.0.0"
-wt-contracts = ">=0.1.0,<1.0.0"
+wt-contracts = ">=0.2.0,<1.0.0"
 questionary = ">=2.0.0,<3.0.0"

--- a/wt-compiler/src/wt_compiler/compiler.py
+++ b/wt-compiler/src/wt_compiler/compiler.py
@@ -10,11 +10,13 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NamedTuple
 
+import jsonschema  # type: ignore[import-untyped]  # transitive dep via wt-contracts; no stubs in wt-compiler env
 import pydot as dot
 import ruamel.yaml
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rattler import Channel, MatchSpec, NamelessMatchSpec
+from wt_contracts import ValidationError
 
 from wt_compiler.artifacts import (
     Dags,
@@ -78,6 +80,39 @@ def _load_default_injections() -> PixiTomlFragment:
     return PixiTomlFragment.from_file(
         DEFAULT_INJECTIONS_PATH, diagnostic_label="default-env-injections"
     )
+
+
+def _check_artifact_is_valid_jsonschema(schema: dict[str, Any], artifact_name: str) -> None:
+    """Validate a compiled artifact against the JSON Schema meta-schema.
+
+    Args:
+        schema: Compiled artifact contents to validate.
+        artifact_name: Human-readable artifact name (e.g. ``"params.json"``)
+            used in the surfaced error message.
+
+    Raises:
+        ValidationError: If ``schema`` is not a valid JSON Schema. The wrapped
+            ``jsonschema.SchemaError`` is surfaced as a single
+            :class:`wt_contracts.ValidationErrorItemDict` so the failure travels
+            through the project's existing error wire format.
+    """
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except jsonschema.SchemaError as e:
+        raise ValidationError(
+            [
+                {
+                    "message": (
+                        f"Compiled artifact {artifact_name!r} is not a valid "
+                        f"JSON Schema: {e.message}"
+                    ),
+                    "path": list(e.absolute_path),
+                    "schema_path": list(e.absolute_schema_path),
+                    "validator": e.validator if isinstance(e.validator, str) else None,
+                    "input": e.instance,
+                }
+            ]
+        ) from e
 
 
 def compute_merged_default_feature(
@@ -913,20 +948,19 @@ class DagCompiler(BaseModel):
         params_schema_flat = self.get_params_jsonschema(flat=True)
         params_schema_hierarchical = self.get_params_jsonschema(flat=False)
 
-        # Hierarchical schema gets the full override set; flat schema gets only
-        # the $defs subset so it remains a valid JSON Schema when a task
-        # contributes a placeholder (e.g. `oneOf: []`) that is filled by
-        # rjsf-overrides. properties/uiSchema overrides are written against the
-        # hierarchical layout and would mis-target the flat schema.
         if self.spec.rjsf_overrides:
             params_schema_hierarchical = self.spec.rjsf_overrides.apply_overrides(
                 params_schema_hierarchical
             )
-            params_schema_flat = self.spec.rjsf_overrides.apply_defs_only(params_schema_flat)
 
         def _mdump(j: ReactJSONSchemaFormConfiguration) -> dict[str, Any]:
             result: dict[str, Any] = j.model_dump(by_alias=True, exclude_none=True)
             return result
+
+        params_flat_dict = _mdump(params_schema_flat)
+        params_hier_dict = _mdump(params_schema_hierarchical)
+        _check_artifact_is_valid_jsonschema(params_flat_dict, "params.json")
+        _check_artifact_is_valid_jsonschema(params_hier_dict, "rjsf.json")
 
         if on_progress is not None:
             on_progress("Rendering DAGs...")
@@ -945,8 +979,8 @@ class DagCompiler(BaseModel):
         package = PackageDirectory(
             dags=dags,
             **{  # type: ignore[arg-type]
-                "rjsf.json": _mdump(params_schema_hierarchical),
-                "params.json": _mdump(params_schema_flat),
+                "rjsf.json": params_hier_dict,
+                "params.json": params_flat_dict,
                 "cli.py": self.ruffrender(
                     "pkg/cli.jinja2",
                     release_name=self.release_name,

--- a/wt-compiler/src/wt_compiler/compiler.py
+++ b/wt-compiler/src/wt_compiler/compiler.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NamedTuple
 
-import jsonschema  # type: ignore[import-untyped]  # transitive dep via wt-contracts; no stubs in wt-compiler env
+import jsonschema
 import pydot as dot
 import ruamel.yaml
 from jinja2 import Environment, FileSystemLoader

--- a/wt-compiler/src/wt_compiler/jsonschema.py
+++ b/wt-compiler/src/wt_compiler/jsonschema.py
@@ -267,30 +267,3 @@ class ReactJSONSchemaFormOverrides(BaseModel):
             uiSchema=_apply_dict_overrides(self.uiSchema, initial_uischema),
             additionalProperties=initial.additionalProperties,
         )
-
-    def apply_defs_only(
-        self,
-        initial: ReactJSONSchemaFormConfiguration,
-    ) -> ReactJSONSchemaFormConfiguration:
-        """Apply only $defs overrides; leave properties and uiSchema untouched.
-
-        Used for the flat ``params.json`` artifact, whose top-level shape
-        differs from the hierarchical ``rjsf.json`` so ``properties.*`` and
-        ``uiSchema`` overrides written for the hierarchical layout would
-        silently mis-target. ``$defs`` is shared between the two artifacts,
-        so its overrides apply cleanly to both.
-
-        Args:
-            initial: The initial configuration to override
-
-        Returns:
-            A new configuration with only ``$defs`` overrides applied
-        """
-        initial_defs = copy.deepcopy(initial.definitions)
-        return ReactJSONSchemaFormConfiguration(
-            title=initial.title,
-            properties=initial.properties,
-            **{"$defs": _apply_dict_overrides(self.definitions, initial_defs)},
-            uiSchema=initial.uiSchema,
-            additionalProperties=initial.additionalProperties,
-        )

--- a/wt-compiler/tests/test_compiler.py
+++ b/wt-compiler/tests/test_compiler.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import ruamel.yaml
+from wt_contracts import ValidationError
 
 from wt_compiler.artifacts import (
     Dags,
@@ -1263,10 +1264,21 @@ class TestHatchDynamicVersion:
         assert version == "1.3.7"
 
 
-class TestRjsfOverridesAppliedToFlatSchemaDefs:
-    """MRE: compiled `params.json` must be a valid JSON Schema even when a task contributes a `$defs` entry with an empty `oneOf: []` placeholder filled by `rjsf-overrides.$defs`."""
+class TestCompiledArtifactsAreValidJsonSchema:
+    """Compile-time validation that ``params.json`` and ``rjsf.json`` are valid JSON Schemas.
 
-    def test_defs_override_propagates_to_flat_params_schema(self, merged_default_feature):
+    ``rjsf-overrides`` are a UI-layer concern bound to ``rjsf.json``; they are
+    not applied to the flat ``params.json``, which is derived purely from task
+    contracts. If a task contributes a malformed placeholder (e.g.
+    ``oneOf: []``) to its contract, the resulting ``params.json`` would be an
+    invalid JSON Schema. The compiler must surface that failure as a
+    :class:`wt_contracts.ValidationError`, naming the offending artifact, so
+    callers get the project's standard error wire format rather than a raw
+    ``jsonschema.SchemaError``.
+    """
+
+    def test_invalid_params_json_raises_validation_error(self, merged_default_feature):
+        """A task contract with ``oneOf: []`` makes ``params.json`` invalid; compile() must surface it."""
         task = KnownTask(
             importable_reference="mymod.with_grouper",
             json_schema={
@@ -1276,7 +1288,7 @@ class TestRjsfOverridesAppliedToFlatSchemaDefs:
                         "type": "object",
                         "properties": {
                             "index_name": {
-                                "oneOf": [],  # placeholder, filled by rjsf-overrides
+                                "oneOf": [],
                                 "type": "string",
                             },
                         },
@@ -1289,7 +1301,7 @@ class TestRjsfOverridesAppliedToFlatSchemaDefs:
         try:
             spec = Spec(
                 **{
-                    "id": "defs_override_mre",
+                    "id": "invalid_params_mre",
                     "requirements": [],
                     "rjsf-overrides": ReactJSONSchemaFormOverrides(
                         **{
@@ -1314,24 +1326,76 @@ class TestRjsfOverridesAppliedToFlatSchemaDefs:
                 spec=spec,
                 wt_runner_channel="https://repo.prefix.dev/ecoscope-workflows/",
             )
-            artifacts = compiler.compile(
-                spec_relpath="spec.yaml",
-                merged_default_feature=merged_default_feature,
-            )
+            with pytest.raises(ValidationError) as exc_info:
+                compiler.compile(
+                    spec_relpath="spec.yaml",
+                    merged_default_feature=merged_default_feature,
+                )
         finally:
             known_tasks.clear()
 
-        flat = artifacts.package.params_json
+        assert len(exc_info.value.errors) == 1
+        err = exc_info.value.errors[0]
+        assert err["validator"] == "minItems"
+        assert "params.json" in err["message"]
+        assert "is not a valid JSON Schema" in err["message"]
+        # rjsf.json is checked after params.json; the params.json failure
+        # short-circuits compile(), so only that single error is surfaced.
+        assert err["input"] == []
 
-        # Root cause: $defs override must reach the flat schema.
-        assert flat["$defs"]["ValueGrouper"]["properties"]["index_name"]["oneOf"] == [
-            {"const": "a", "title": "A"},
-            {"const": "b", "title": "B"},
-        ]
+    def test_invalid_rjsf_json_raises_validation_error(self, merged_default_feature):
+        """An rjsf-overrides entry that yields an invalid rjsf.json must be surfaced."""
+        task = KnownTask(
+            importable_reference="mymod.with_grouper",
+            json_schema={
+                "properties": {"grouper": {"$ref": "#/$defs/ValueGrouper"}},
+                "$defs": {
+                    "ValueGrouper": {
+                        "type": "object",
+                        "properties": {"index_name": {"type": "string"}},
+                        "required": ["index_name"],
+                    },
+                },
+            },
+        )
+        known_tasks["with_grouper"] = {"mymod": task}
+        try:
+            spec = Spec(
+                **{
+                    "id": "invalid_rjsf_mre",
+                    "requirements": [],
+                    "rjsf-overrides": ReactJSONSchemaFormOverrides(
+                        **{
+                            "$defs": {
+                                "ValueGrouper.properties.index_name.type": "not-a-type",
+                            },
+                        }
+                    ),
+                    "workflow": [
+                        TaskInstance(
+                            id="step_one",
+                            name="Step One",
+                            task="mymod.with_grouper",
+                        ),
+                    ],
+                }
+            )
+            compiler = DagCompiler(
+                spec=spec,
+                wt_runner_channel="https://repo.prefix.dev/ecoscope-workflows/",
+            )
+            with pytest.raises(ValidationError) as exc_info:
+                compiler.compile(
+                    spec_relpath="spec.yaml",
+                    merged_default_feature=merged_default_feature,
+                )
+        finally:
+            known_tasks.clear()
 
-        # Symptom: flat schema must be a valid JSON Schema (oneOf requires minItems: 1).
-        jsonschema = pytest.importorskip("jsonschema")
-        jsonschema.validators.Draft202012Validator.check_schema(flat)
+        assert len(exc_info.value.errors) == 1
+        err = exc_info.value.errors[0]
+        assert "rjsf.json" in err["message"]
+        assert "is not a valid JSON Schema" in err["message"]
 
 
 if __name__ == "__main__":

--- a/wt-compiler/tests/test_jsonschema.py
+++ b/wt-compiler/tests/test_jsonschema.py
@@ -154,24 +154,6 @@ class TestReactJSONSchemaFormOverrides:
         assert updated.properties["task1"]["type"] == "number"
         assert updated.uiSchema["task1"]["ui:widget"] == "range"
 
-    def test_apply_defs_only_leaves_properties_and_uischema_untouched(self):
-        """$defs overrides apply; properties and uiSchema pass through unchanged."""
-        overrides = ReactJSONSchemaFormOverrides(
-            properties={"task1.x.type": "number"},
-            uiSchema={"task1.ui:widget": "textarea"},
-            **{"$defs": {"ValueGrouper.oneOf": [{"const": "a"}]}},
-        )
-        config = ReactJSONSchemaFormConfiguration(
-            title="Original",
-            properties={"task1": {"x": {"type": "string"}}},
-            uiSchema={"task1": {"ui:widget": "text"}},
-            **{"$defs": {"ValueGrouper": {"oneOf": []}}},
-        )
-        updated = overrides.apply_defs_only(config)
-        assert updated.definitions["ValueGrouper"]["oneOf"] == [{"const": "a"}]
-        assert updated.properties == {"task1": {"x": {"type": "string"}}}
-        assert updated.uiSchema == {"task1": {"ui:widget": "text"}}
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/wt-compiler/uv.lock
+++ b/wt-compiler/uv.lock
@@ -768,6 +768,18 @@ wheels = [
 ]
 
 [[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260508"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/d8/7ba8007c48e0de93d82268e0447312c9c28d90ac7a8f73e034356bb40921/types_jsonschema-4.26.0.20260508.tar.gz", hash = "sha256:ae0be85ac6ec0cb94a98f75f876b0620cf2afa3e37fdf8460203f4d05f745acb", size = 16602, upload-time = "2026-05-08T04:51:45.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/55/4f25833c410426b1f359dd579f3b3d1ee0f43f5674b23a815f396d3ea63c/types_jsonschema-4.26.0.20260508-py3-none-any.whl", hash = "sha256:4ec1dea0a757c8c2e2aa7bc085612fb54e1ae9562428d5da6f26dd7a0f24dbc2", size = 16062, upload-time = "2026-05-08T04:51:44.437Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -821,6 +833,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [package.dev-dependencies]
@@ -832,6 +845,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
@@ -851,6 +865,7 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "tomli-w", specifier = ">=1.0.0" },
+    { name = "types-jsonschema", marker = "extra == 'dev'" },
     { name = "wt-contracts", editable = "../wt-contracts" },
 ]
 provides-extras = ["dev"]
@@ -864,6 +879,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "types-jsonschema" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Revert the `apply_defs_only` call (introduced in 9f053a3) and delete the now-unused method. `params.json` is derived purely from task contracts; `rjsf-overrides` are a UI-layer concern bound to `rjsf.json`.
- Address the original defect (an artifact escaping as a malformed JSON Schema) by running `jsonschema.Draft202012Validator.check_schema` against both compiled artifacts at the end of `compile()` and raising `wt_contracts.ValidationError` on failure — surfacing the issue through the project's existing error wire format rather than a raw `jsonschema.SchemaError`.
- Add `types-jsonschema` to dev deps for type-checking the new validator call.

Closes #172

## Test plan
- [x] `uv run pytest` in `wt-compiler/`
- [x] Confirm downstream `ecoscope-platform-workflows-releases/event-details#38` is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)