### PR TITLE
Add get params to workflow runner app

### DIFF
--- a/wt-compiler/src/wt_compiler/templates/pkg/cli.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/pkg/cli.jinja2
@@ -161,15 +161,16 @@ def run(
 @cli.command()
 @click.argument(
     "metadata_attribute",
-    type=click.Choice(["rjsf", "data-connection-property-names"]),
+    type=click.Choice(["rjsf", "params", "data-connection-property-names"]),
     required=True,
 )
 def get(metadata_attribute: str) -> None:
     """Get the metadata for the workflow."""
-    from .metadata import get_data_connection_property_names, load_rjsf_schema
+    from .metadata import get_data_connection_property_names, load_rjsf_schema, load_params_schema
 
     getter = {
         "rjsf": load_rjsf_schema,
+        "params": load_params_schema,
         "data-connection-property-names": get_data_connection_property_names,
     }.get(metadata_attribute)
     if getter is None:

--- a/wt-compiler/src/wt_compiler/templates/pkg/cli.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/pkg/cli.jinja2
@@ -166,7 +166,7 @@ def run(
 )
 def get(metadata_attribute: str) -> None:
     """Get the metadata for the workflow."""
-    from .metadata import get_data_connection_property_names, load_rjsf_schema, load_params_schema
+    from .metadata import get_data_connection_property_names, load_params_schema, load_rjsf_schema
 
     getter = {
         "rjsf": load_rjsf_schema,

--- a/wt-runner/src/wt_runner/app.py
+++ b/wt-runner/src/wt_runner/app.py
@@ -642,6 +642,19 @@ async def rjsf(invoker: AbstractInvoker = Depends(resolve_invoker)) -> dict[str,
     return await _get_metadata_attribute("rjsf", invoker)
 
 
+@app.get("/params", status_code=200)
+async def params(invoker: AbstractInvoker = Depends(resolve_invoker)) -> dict[str, Any]:
+    """Get the params json for the workflow.
+
+    Args:
+        invoker: Invoker instance
+
+    Returns:
+        Workflow's params.json
+    """
+    return await _get_metadata_attribute("params", invoker)
+
+
 @app.get("/data-connection-property-names", status_code=200)
 async def data_connection_property_names(
     invoker: AbstractInvoker = Depends(resolve_invoker),

--- a/wt-runner/tests/test_app.py
+++ b/wt-runner/tests/test_app.py
@@ -288,9 +288,7 @@ async def test_convert_unexpected_envelope():
     ("endpoint", "attr"),
     [("/rjsf", "rjsf"), ("/params", "params")],
 )
-def test_metadata_endpoint_returns_invoker_output(
-    client: TestClient, endpoint: str, attr: str
-):
+def test_metadata_endpoint_returns_invoker_output(client: TestClient, endpoint: str, attr: str):
     """GET /rjsf and /params return the parsed CLI output and call ``get <attr>``."""
     expected = {"some": "schema"}
     mock_invoker = AsyncMock()

--- a/wt-runner/tests/test_app.py
+++ b/wt-runner/tests/test_app.py
@@ -284,6 +284,29 @@ async def test_convert_unexpected_envelope():
         await _convert("formdata", "params", '{"input": "data"}', mock_invoker)
 
 
+@pytest.mark.parametrize(
+    ("endpoint", "attr"),
+    [("/rjsf", "rjsf"), ("/params", "params")],
+)
+def test_metadata_endpoint_returns_invoker_output(
+    client: TestClient, endpoint: str, attr: str
+):
+    """GET /rjsf and /params return the parsed CLI output and call ``get <attr>``."""
+    expected = {"some": "schema"}
+    mock_invoker = AsyncMock()
+    mock_invoker.check_output = AsyncMock(return_value=json.dumps(expected))
+
+    app.dependency_overrides[resolve_invoker] = lambda: mock_invoker
+    try:
+        response = client.get(endpoint)
+    finally:
+        app.dependency_overrides.pop(resolve_invoker, None)
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    mock_invoker.check_output.assert_called_once_with(["get", attr])
+
+
 @pytest.mark.parametrize("endpoint", ["/formdata-to-params", "/params-to-formdata"])
 def test_convert_endpoint_422_body_matches_validation_error_response(
     client: TestClient, endpoint: str


### PR DESCRIPTION
## :earth_americas: Summary
Closes #177 

## :package: Proposed Changes
- Adds an equivalent get route for params.json as already exists for rjsf.json
- Updates the cli.py workflow template to expose params as a metadata attribute
