### PR TITLE
Update CHANGELOGs for release 2026-05-28

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.8.0 — 2026-05-28
+
+- Add `params` choice to the `wt-compiler get <metadata_attribute>` CLI, exposing the workflow's `params.json` schema alongside the existing `rjsf` and `data-connection-property-names` attributes ([#178](https://github.com/wildlife-dynamics/wt/pull/178))
+- Bump `wt-runner` floor to `>=0.3.0` in `default-env-injections.toml` to match the new `/params` endpoint added in `wt-runner` v0.3.0
+
 ## v0.7.0 — 2026-05-14
 
 - Drop `rjsf-overrides` `$defs` propagation to the flat `params.json` artifact; overrides now apply only to `rjsf.json`. Removes `ReactJSONSchemaFormOverrides.apply_defs_only()` ([#173](https://github.com/wildlife-dynamics/wt/pull/173))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -158,7 +158,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.7.0"
+version = "0.8.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-compiler/src/wt_compiler/default-env-injections.toml
+++ b/wt-compiler/src/wt_compiler/default-env-injections.toml
@@ -24,7 +24,7 @@ opentelemetry-api = { version = ">=1.20.0,<2.0.0", channel = "conda-forge" }
 wt-task           = { version = ">=0.1.3,<1.0.0",  channel = "ecoscope-workflows" }
 
 [feature.runner.dependencies]
-wt-runner = { version = ">=0.2.0,<1.0.0", channel = "ecoscope-workflows" }
+wt-runner = { version = ">=0.3.0,<1.0.0", channel = "ecoscope-workflows" }
 
 [feature.test.dependencies]
 pandas         = { version = "*",        channel = "conda-forge" }

--- a/wt-compiler/tests/test_default_env_injections.py
+++ b/wt-compiler/tests/test_default_env_injections.py
@@ -28,7 +28,7 @@ EXPECTED_SPECS = {
         ("wt-task", ">=0.1.3,<1.0.0", RELEASE_CHANNEL.base_url),
     ],
     "runner": [
-        ("wt-runner", ">=0.2.0,<1.0.0", RELEASE_CHANNEL.base_url),
+        ("wt-runner", ">=0.3.0,<1.0.0", RELEASE_CHANNEL.base_url),
     ],
     "test": [
         ("pandas", "*", CONDA_FORGE_CHANNEL.base_url),

--- a/wt-runner-gcp/pyproject.toml
+++ b/wt-runner-gcp/pyproject.toml
@@ -108,7 +108,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-runner-gcp"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-runner/CHANGELOG.md
+++ b/wt-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0 — 2026-05-28
+
+- Add `GET /params` endpoint that returns the workflow's `params.json` by proxying the compiled CLI's new `get params` metadata attribute ([#178](https://github.com/wildlife-dynamics/wt/pull/178))
+
 ## v0.2.0 — 2026-05-13
 
 - Register the new `SandboxInvoker` and `CloudRunJobsSandboxInvoker` in the `INVOKERS` dispatch map ([#164](https://github.com/wildlife-dynamics/wt/pull/164))

--- a/wt-runner/pyproject.toml
+++ b/wt-runner/pyproject.toml
@@ -167,7 +167,7 @@ extend-immutable-calls = [
 
 [tool.pixi.package]
 name = "wt-runner"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
## Summary
Closes #180 
- **wt-compiler** 0.7.0 → **0.8.0** (minor): add `params` choice to the `get <metadata_attribute>` CLI; bump wt-runner floor in `default-env-injections.toml` to `>=0.3.0`.
- **wt-runner** 0.2.0 → **0.3.0** (minor): add `GET /params` endpoint.
- **wt-runner-gcp** 0.2.0 → **0.3.0** (lockstep with wt-runner).

## Test plan

- [ ] CI green on this branch
- [ ] After merge: tag `wt-compiler/v0.8.0`, `wt-runner/v0.3.0`, `wt-runner-gcp/v0.3.0` and push one-at-a-time to trigger publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)