### PR TITLE
Replace ephemeral values nested in `data` fields of results snapshot json tests

### DIFF
--- a/wt-compiler/src/wt_compiler/templates/tests/test_results.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/tests/test_results.jinja2
@@ -18,18 +18,6 @@ _UUID_RE = re.compile(
 )
 
 
-def _replace_ephemeral_values(value, tmp_root: str):
-    if isinstance(value, dict):
-        return {k: _replace_ephemeral_values(v, tmp_root) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_replace_ephemeral_values(v, tmp_root) for v in value]
-    if isinstance(value, str):
-        if value.startswith(tmp_root):
-            return "tmpfile"
-        return _UUID_RE.sub("uuid", value)
-    return value
-
-
 def test_failure_response(
     response_json_failure: dict, snapshot_json: SnapshotAssertion
 ):
@@ -53,7 +41,15 @@ def test_dashboard_json(
 ):
     # replace any UUIDs or paths to test output in the response_json
     tmp_root = str(tmp_path.parent)
-    assert _replace_ephemeral_values(response_json_success, tmp_root) == snapshot_json()
+
+    def _replace_ephemeral_values(*, data, path):
+        if not isinstance(data, str):
+            return data
+        if data.startswith(tmp_root):
+            return "tmpfile"
+        return _UUID_RE.sub("uuid", data)
+
+    assert response_json_success == snapshot_json(matcher=_replace_ephemeral_values)
 
 
 @pytest.mark.asyncio

--- a/wt-compiler/src/wt_compiler/templates/tests/test_results.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/tests/test_results.jinja2
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import re
+from pathlib import Path
 from typing import Any, Coroutine
 
 import pytest
@@ -17,13 +18,13 @@ _UUID_RE = re.compile(
 )
 
 
-def _replace_ephemeral_values(value):
+def _replace_ephemeral_values(value, tmp_root: str):
     if isinstance(value, dict):
-        return {k: _replace_ephemeral_values(v) for k, v in value.items()}
+        return {k: _replace_ephemeral_values(v, tmp_root) for k, v in value.items()}
     if isinstance(value, list):
-        return [_replace_ephemeral_values(v) for v in value]
+        return [_replace_ephemeral_values(v, tmp_root) for v in value]
     if isinstance(value, str):
-        if value.startswith("/tmp/pytest-"):
+        if value.startswith(tmp_root):
             return "tmpfile"
         return _UUID_RE.sub("uuid", value)
     return value
@@ -46,10 +47,13 @@ def test_failure_response(
 
 
 def test_dashboard_json(
-    response_json_success: dict, snapshot_json: SnapshotAssertion
+    response_json_success: dict,
+    snapshot_json: SnapshotAssertion,
+    tmp_path: Path,
 ):
     # replace any UUIDs or paths to test output in the response_json
-    assert _replace_ephemeral_values(response_json_success) == snapshot_json()
+    tmp_root = str(tmp_path.parent)
+    assert _replace_ephemeral_values(response_json_success, tmp_root) == snapshot_json()
 
 
 @pytest.mark.asyncio

--- a/wt-compiler/src/wt_compiler/templates/tests/test_results.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/tests/test_results.jinja2
@@ -1,6 +1,7 @@
 {{ file_header }}
 import asyncio
 import json
+import re
 from typing import Any, Coroutine
 
 import pytest
@@ -9,6 +10,23 @@ from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from conftest import MATCHSPEC_OVERRIDE, ReconstructedOtelSpan, RunParams
+
+
+_UUID_RE = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
+)
+
+
+def _replace_ephemeral_values(value):
+    if isinstance(value, dict):
+        return {k: _replace_ephemeral_values(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_replace_ephemeral_values(v) for v in value]
+    if isinstance(value, str):
+        if value.startswith("/tmp/pytest-"):
+            return "tmpfile"
+        return _UUID_RE.sub("uuid", value)
+    return value
 
 
 def test_failure_response(
@@ -28,18 +46,10 @@ def test_failure_response(
 
 
 def test_dashboard_json(
-    no_data: bool, response_json_success: dict, snapshot_json: SnapshotAssertion
+    response_json_success: dict, snapshot_json: SnapshotAssertion
 ):
-    if no_data:
-        kws = {}
-    else:
-        exclude_results_data = {
-            f"result.views.{key}.{i}.data": (str,)
-            for key in response_json_success["result"]["views"]
-            for i, _ in enumerate(response_json_success["result"]["views"][key])
-        }
-        kws = {"matcher": path_type(exclude_results_data)}
-    assert response_json_success == snapshot_json(**kws)
+    # replace any UUIDs or paths to test output in the response_json
+    assert _replace_ephemeral_values(response_json_success) == snapshot_json()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## :earth_americas: Summary
Closes #183 

## :package: Proposed Changes
Reworks `test_dashboard_json` to ignore values (by matching against known patterns) at all levels of nesting within the result.json under test.

I've tested this over at https://github.com/ecoscope-platform-workflows-releases/subject-tracking/pull/202, you can see the new results snapshots in the diff, and that the tests, with the code from this PR manually inserted, are passing.

Happily (as you can see in the diff), this also allows us to include stat widgets in the snapshot tests :partying_face: 