### PR TITLE
feat(wt-invokers): add `--dangerously-skip-results-archive-upload` to sandbox invoker

### DIFF
--- a/tests/reverse_integration/manifest.yaml
+++ b/tests/reverse_integration/manifest.yaml
@@ -38,6 +38,7 @@ _compile_only: &compile_only
     - file: VERSION.yaml
       allowed_variance:
         - 'MIN: \d+'
+        - 'PATCH: \d+'
     - file: Dockerfile
       allowed_variance:
         - 'PIXI_VERSION=\S+'
@@ -68,6 +69,7 @@ _env_overrides: &env_overrides
     - file: VERSION.yaml
       allowed_variance:
         - 'MIN: \d+'
+        - 'PATCH: \d+'
     - file: Dockerfile
       allowed_variance:
         - 'PIXI_VERSION=\S+'

--- a/wt-invokers/src/wt_invokers/cloud_run_jobs.py
+++ b/wt-invokers/src/wt_invokers/cloud_run_jobs.py
@@ -107,7 +107,8 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
         lithops_config_text: str | None = None,  # noqa: ARG002  # interface compatibility — proxy invoker doesn't run lithops
         *,
         environment_tar_url: str,
-        results_upload_url: str,
+        results_upload_url: str | None = None,
+        skip_results_archive_upload: bool = False,
         job_name: str,
         project_id: str,
         region: str = "us-central1",
@@ -128,11 +129,42 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
                 with the abstract :meth:`_run` signature.
             environment_tar_url: Signed URL of the pixi-pack environment tarball.
             results_upload_url: Signed URL where the results archive should be
-                uploaded after the workflow finishes.
+                uploaded after the workflow finishes. Required unless
+                ``skip_results_archive_upload`` is ``True``, in which case it
+                must be omitted.
+            skip_results_archive_upload: Skip the post-run results archive
+                upload inside the sandbox container. Requires ``results_url``
+                to be a real destination (not the sandbox staging default
+                ``file:///results``) and is mutually exclusive with
+                ``results_upload_url``.
             job_name: Short name of the pre-deployed Cloud Run Job.
             project_id: GCP project ID.
             region: GCP region (default ``us-central1``).
+
+        Raises:
+            ValueError: If ``results_upload_url`` and
+                ``skip_results_archive_upload`` are combined inconsistently.
+                Validation happens eagerly here — mirroring the sandbox CLI's
+                rules — because the job runs asynchronously, so a CLI-level
+                error would otherwise only surface inside the container.
         """
+        if not skip_results_archive_upload and results_upload_url is None:
+            raise ValueError(
+                "results_upload_url is required unless skip_results_archive_upload=True"
+            )
+        if skip_results_archive_upload:
+            if results_upload_url is not None:
+                raise ValueError(
+                    "results_upload_url is mutually exclusive with "
+                    "skip_results_archive_upload=True"
+                )
+            if results_url == "file:///results":
+                raise ValueError(
+                    "skip_results_archive_upload=True requires results_url "
+                    "to point at a real destination, not the sandbox staging "
+                    "default file:///results"
+                )
+
         config_as_json = yaml_to_json(text=config_text)
         fq_job_name = f"projects/{project_id}/locations/{region}/jobs/{job_name}"
         await self._ensure_job_exists(fq_job_name)
@@ -145,8 +177,6 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
             workflow_run_id,
             "--environment-tar-url",
             environment_tar_url,
-            "--results-upload-url",
-            results_upload_url,
             "--results-url",
             results_url,
             "--config-json",
@@ -154,6 +184,10 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
             "--execution-mode",
             execution_mode,
         ]
+        if skip_results_archive_upload:
+            container_args.append("--dangerously-skip-results-archive-upload")
+        elif results_upload_url is not None:
+            container_args.extend(["--results-upload-url", results_upload_url])
         if mock_io:
             container_args.append("--mock-io")
         else:

--- a/wt-invokers/src/wt_invokers/mixins.py
+++ b/wt-invokers/src/wt_invokers/mixins.py
@@ -265,6 +265,13 @@ class UploadResultsArchiveMixin:
     Supports ``file://`` destinations for local testing as well as ``http://``
     / ``https://`` signed-URL uploads via ``PUT`` (used for GCS signed URLs).
 
+    If the ``skip_results_archive_upload`` run-arg is truthy, the hook is a
+    no-op: no archive is created and no upload occurs. In that mode the
+    ``results_url`` / ``results_upload_url`` validations are also skipped —
+    the workflow is expected to write results directly to a destination the
+    caller controls, so ``results_upload_url`` is not required and
+    ``results_url`` need not be a ``file://`` URL.
+
     This hook runs even when the workflow exited non-zero so that a
     ``result.json`` describing the failure is still uploaded.
 
@@ -283,6 +290,8 @@ class UploadResultsArchiveMixin:
 
     async def _post_run(self) -> None:
         await super()._post_run()  # type: ignore[misc]
+        if self.run_args.get("skip_results_archive_upload"):
+            return
         results_url = self.run_args.get("results_url")
         if not results_url:
             raise ValueError("results_url is required -- pass it as an arg to run()")

--- a/wt-invokers/src/wt_invokers/sandbox.py
+++ b/wt-invokers/src/wt_invokers/sandbox.py
@@ -201,11 +201,25 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--workflow-run-id", required=True)
     p.add_argument("--environment-tar-url", required=True)
-    p.add_argument("--results-upload-url", required=True)
+    # Effectively required unless --dangerously-skip-results-archive-upload is
+    # passed; requiredness is enforced post-parse in main() so the error
+    # message can reference the skip flag.
+    p.add_argument("--results-upload-url", default=None)
     p.add_argument(
         "--results-url",
         default="file:///results",
         help="Local directory URL for workflow outputs (file://)",
+    )
+    p.add_argument(
+        "--dangerously-skip-results-archive-upload",
+        dest="skip_results_archive_upload",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the post-run results archive upload. Requires --results-url "
+            "to be set to a real destination (not the default file:///results) "
+            "and is mutually exclusive with --results-upload-url."
+        ),
     )
     p.add_argument("--config-json", required=True)
     p.add_argument(
@@ -239,6 +253,7 @@ async def _amain(args: argparse.Namespace) -> int:
         otel_console_exporter_dst=args.otel_console_exporter_dst,
         environment_tar_url=args.environment_tar_url,
         results_upload_url=args.results_upload_url,
+        skip_results_archive_upload=args.skip_results_archive_upload,
     )
     return await invoker.wait()
 
@@ -247,6 +262,24 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point: parse args, run the sandbox invoker, exit with its code."""
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
+    if not args.skip_results_archive_upload:
+        if args.results_upload_url is None:
+            parser.error(
+                "--results-upload-url is required unless "
+                "--dangerously-skip-results-archive-upload is passed"
+            )
+    else:
+        if args.results_upload_url is not None:
+            parser.error(
+                "--results-upload-url is mutually exclusive with "
+                "--dangerously-skip-results-archive-upload"
+            )
+        if args.results_url == "file:///results":
+            parser.error(
+                "--dangerously-skip-results-archive-upload requires --results-url "
+                "to point at a real destination, not the staging default "
+                "file:///results"
+            )
     return asyncio.run(_amain(args))
 
 

--- a/wt-invokers/tests/test_cloud_run_jobs.py
+++ b/wt-invokers/tests/test_cloud_run_jobs.py
@@ -195,22 +195,21 @@ async def test_ensure_job_exists_raises_clear_error_on_missing(
             )
 
 
-@pytest.mark.asyncio
-async def test_run_builds_container_args(mock_run_modules: Any) -> None:
-    """Container args forwarded to the sandbox CLI include all workflow inputs."""
-    captured: dict[str, Any] = {}
+class FakeContainerOverride:
+    def __init__(self) -> None:
+        self.args: list[str] = []
+        self.env: list[Any] = []
 
+
+class FakeOverrides:
+    def __init__(self) -> None:
+        self.container_overrides: list[Any] = []
+
+
+def _make_fakes(captured: dict[str, Any]) -> tuple[Any, type]:
+    """Build a fake JobsAsyncClient and RunJobRequest that record into ``captured``."""
     fake_client = MagicMock()
     fake_client.get_job = AsyncMock()
-
-    class FakeContainerOverride:
-        def __init__(self) -> None:
-            self.args: list[str] = []
-            self.env: list[Any] = []
-
-    class FakeOverrides:
-        def __init__(self) -> None:
-            self.container_overrides: list[Any] = []
 
     class FakeRunJobRequest:
         class Overrides:
@@ -233,10 +232,18 @@ async def test_run_builds_container_args(mock_run_modules: Any) -> None:
         return op
 
     fake_client.run_job = fake_run_job
+    return fake_client, FakeRunJobRequest
+
+
+@pytest.mark.asyncio
+async def test_run_builds_container_args(mock_run_modules: Any) -> None:
+    """Container args forwarded to the sandbox CLI include all workflow inputs."""
+    captured: dict[str, Any] = {}
+    fake_client, fake_request_cls = _make_fakes(captured)
 
     with (
         patch("wt_invokers.cloud_run_jobs.JobsAsyncClient", return_value=fake_client),
-        patch("wt_invokers.cloud_run_jobs.RunJobRequest", FakeRunJobRequest),
+        patch("wt_invokers.cloud_run_jobs.RunJobRequest", fake_request_cls),
         patch("wt_invokers.cloud_run_jobs.EnvVar", MagicMock),
     ):
         inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("my-wf>=1.0.0"))
@@ -274,3 +281,93 @@ async def test_run_builds_container_args(mock_run_modules: Any) -> None:
     assert "http://otel" in args
     assert "--otel-console-exporter-dst" in args
     assert "stdout" in args
+    assert "--dangerously-skip-results-archive-upload" not in args
+
+
+@pytest.mark.asyncio
+async def test_run_skip_upload_builds_container_args(mock_run_modules: Any) -> None:
+    """Skipping the upload forwards the skip flag and omits --results-upload-url."""
+    captured: dict[str, Any] = {}
+    fake_client, fake_request_cls = _make_fakes(captured)
+
+    with (
+        patch("wt_invokers.cloud_run_jobs.JobsAsyncClient", return_value=fake_client),
+        patch("wt_invokers.cloud_run_jobs.RunJobRequest", fake_request_cls),
+        patch("wt_invokers.cloud_run_jobs.EnvVar", MagicMock),
+    ):
+        inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("my-wf>=1.0.0"))
+        await inv.run(
+            workflow_run_id="run-42",
+            config_text="k: v",
+            results_url="gs://bucket/results",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url="https://e/env.tar",
+            skip_results_archive_upload=True,
+            job_name="j",
+            project_id="p",
+        )
+        await inv.wait()
+
+    args = captured["overrides"].container_overrides[0].args
+    assert "--dangerously-skip-results-archive-upload" in args
+    assert "--results-upload-url" not in args
+    assert "--results-url" in args
+    assert "gs://bucket/results" in args
+
+
+@pytest.mark.asyncio
+async def test_run_skip_upload_with_upload_url_raises(mock_run_modules: Any) -> None:
+    inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("w>=1.0.0"))
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await inv.run(
+            workflow_run_id="r",
+            config_text="k: v",
+            results_url="gs://bucket/results",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url="https://x/e.tar",
+            results_upload_url="https://x/o",
+            skip_results_archive_upload=True,
+            job_name="j",
+            project_id="p",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_missing_upload_url_without_skip_raises(
+    mock_run_modules: Any,
+) -> None:
+    """results_upload_url stays effectively required when not skipping."""
+    inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("w>=1.0.0"))
+    with pytest.raises(ValueError, match="results_upload_url is required"):
+        await inv.run(
+            workflow_run_id="r",
+            config_text="k: v",
+            results_url="file:///r",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url="https://x/e.tar",
+            job_name="j",
+            project_id="p",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_skip_upload_with_default_results_url_raises(
+    mock_run_modules: Any,
+) -> None:
+    """The sandbox staging default results_url is meaningless when not uploading."""
+    inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("w>=1.0.0"))
+    with pytest.raises(ValueError, match="real destination"):
+        await inv.run(
+            workflow_run_id="r",
+            config_text="k: v",
+            results_url="file:///results",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url="https://x/e.tar",
+            skip_results_archive_upload=True,
+            job_name="j",
+            project_id="p",
+        )

--- a/wt-invokers/tests/test_sandbox.py
+++ b/wt-invokers/tests/test_sandbox.py
@@ -312,6 +312,54 @@ async def test_end_to_end_lifecycle_with_mocked_externals(tmp_path: Path) -> Non
     assert inv.is_running is False
 
 
+@pytest.mark.asyncio
+async def test_end_to_end_lifecycle_with_skip_upload(tmp_path: Path) -> None:
+    """With skip_results_archive_upload, wait() succeeds and nothing is uploaded."""
+    source_tar = tmp_path / "env.tar"
+    source_tar.write_bytes(b"fake")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    (results_dir / "result.json").write_text('{"ok": true}')
+
+    inv = SandboxInvoker(
+        matchspec=MatchSpec("my-workflow>=1.0.0"),
+        work_dir=str(tmp_path / "work"),
+    )
+
+    mock_proc = MagicMock()
+    mock_proc.wait.return_value = 0
+
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        patch("wt_invokers.mixins.subprocess.run"),
+        patch("wt_invokers.sandbox.subprocess.Popen", return_value=mock_proc),
+    ):
+        await inv.run(
+            workflow_run_id="r1",
+            config_text="k: v",
+            results_url=f"file://{results_dir}",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url=f"file://{source_tar}",
+            skip_results_archive_upload=True,
+        )
+        exit_code = await inv.wait()
+
+    assert exit_code == 0
+    # No upload artifact was created anywhere under tmp_path.
+    assert not list(tmp_path.rglob("*.tar.gz"))  # noqa: ASYNC240  # test-only local FS scan; no event loop at stake
+    assert inv.is_running is False
+
+
+@pytest.mark.asyncio
+async def test_post_run_skip_accepts_non_file_results_url(tmp_path: Path) -> None:
+    """With the skip flag set, the file:// scheme validation is bypassed."""
+    inv = SandboxInvoker(matchspec=MatchSpec("w>=1.0.0"), work_dir=str(tmp_path))
+    inv._run_args["results_url"] = "gs://bucket/results"
+    inv._run_args["skip_results_archive_upload"] = True
+    await inv._post_run()  # no upload, no validation error
+
+
 # ---------------------------------------------------------------------------
 # check_output
 # ---------------------------------------------------------------------------
@@ -329,6 +377,20 @@ async def test_check_output_is_not_supported(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # CLI main()
 # ---------------------------------------------------------------------------
+
+
+def _cli_args_without_upload_url() -> list[str]:
+    """Required CLI args, minus ``--results-upload-url``."""
+    return [
+        "--matchspec",
+        "w>=1.0.0",
+        "--workflow-run-id",
+        "r",
+        "--environment-tar-url",
+        "https://x/e.tar",
+        "--config-json",
+        "{}",
+    ]
 
 
 def test_cli_parses_required_args() -> None:
@@ -422,3 +484,96 @@ def test_cli_main_invokes_run_and_wait(tmp_path: Path) -> None:
     assert called["run_kwargs"]["workflow_run_id"] == "r1"
     assert called["run_kwargs"]["environment_tar_url"] == f"file://{tmp_path}/env.tar"
     assert called["run_kwargs"]["results_upload_url"] == f"file://{tmp_path}/out.tar.gz"
+    assert called["run_kwargs"]["skip_results_archive_upload"] is False
+
+
+def test_cli_skip_upload_flag_defaults_false() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(
+        [*_cli_args_without_upload_url(), "--results-upload-url", "https://x/o"]
+    )
+    assert args.skip_results_archive_upload is False
+
+
+def test_cli_skip_upload_flag_parses_true() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(
+        [
+            *_cli_args_without_upload_url(),
+            "--dangerously-skip-results-archive-upload",
+        ]
+    )
+    assert args.skip_results_archive_upload is True
+    assert args.results_upload_url is None
+
+
+def test_cli_missing_results_upload_url_without_skip_exits() -> None:
+    """--results-upload-url is still effectively required without the skip flag."""
+    with pytest.raises(SystemExit) as exc:
+        main(_cli_args_without_upload_url())
+    assert exc.value.code != 0
+
+
+def test_cli_skip_upload_mutually_exclusive_with_upload_url() -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                *_cli_args_without_upload_url(),
+                "--results-upload-url",
+                "https://x/o",
+                "--dangerously-skip-results-archive-upload",
+                "--results-url",
+                "file:///real/dest",
+            ]
+        )
+    assert exc.value.code != 0
+
+
+@pytest.mark.parametrize(
+    "results_url_args",
+    [
+        pytest.param([], id="results-url-omitted"),
+        pytest.param(["--results-url", "file:///results"], id="results-url-explicit"),
+    ],
+)
+def test_cli_skip_upload_rejects_default_results_url(
+    results_url_args: list[str],
+) -> None:
+    """Skipping the upload requires --results-url to be a real destination."""
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                *_cli_args_without_upload_url(),
+                "--dangerously-skip-results-archive-upload",
+                *results_url_args,
+            ]
+        )
+    assert exc.value.code != 0
+
+
+def test_cli_main_skip_upload_happy_path(tmp_path: Path) -> None:
+    """With the flag and a real --results-url, run() receives the skip kwarg."""
+    called: dict[str, Any] = {}
+
+    async def fake_run(self: Any, **kwargs: Any) -> None:
+        called["run_kwargs"] = kwargs
+
+    async def fake_wait(self: Any, *args: Any, **kwargs: Any) -> int:
+        return 0
+
+    with (
+        patch.object(SandboxInvoker, "run", new=fake_run),
+        patch.object(SandboxInvoker, "wait", new=fake_wait),
+    ):
+        exit_code = main(
+            [
+                *_cli_args_without_upload_url(),
+                "--dangerously-skip-results-archive-upload",
+                "--results-url",
+                f"file://{tmp_path}/results",
+            ]
+        )
+
+    assert exit_code == 0
+    assert called["run_kwargs"]["skip_results_archive_upload"] is True
+    assert called["run_kwargs"]["results_upload_url"] is None


### PR DESCRIPTION
closes #182
closes #186

## :earth_americas: Summary

Allow sandbox invoker users who trust the code being run to skip the post-run results-archive-upload step (issue #182). The workflow then writes results directly to a destination the user controls.

## :package: Proposed Changes

- UploadResultsArchiveMixin._post_run early-returns when the skip_results_archive_upload run-arg is set, bypassing the results_upload_url requirement and the file:// scheme check on results_url.
- The sandbox CLI gains --dangerously-skip-results-archive-upload. --results-upload-url moves from required=True to post-parse validation: still effectively required without the flag, an error alongside it (mutually exclusive), and the flag rejects the staging default --results-url file:///results.
- CloudRunJobsSandboxInvoker._run accepts skip_results_archive_upload, validates the same rules eagerly (the job is non-waitable, so CLI errors would otherwise surface only inside the container), and forwards the flag / omits --results-upload-url in the container args.