### PR TITLE
In publish.yml, force re-fetch tag to get actual annotation, and thereby fix gh release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,11 @@ jobs:
           TAG: ${{ needs.parse.outputs.package }}/v${{ needs.parse.outputs.version }}
           PACKAGE: ${{ needs.parse.outputs.package }}
         run: |
+          # actions/checkout replaces the annotated tag with a lightweight one
+          # pointing at the commit (actions/checkout#290); re-fetch the real tag
+          # object so %(contents) reads the annotation, not the commit message.
+          git fetch origin --force "refs/tags/${TAG}:refs/tags/${TAG}"
+
           # Try to extract notes from annotated tag (skip the header line)
           annotation="$(git tag -l --format='%(contents)' "$TAG")"
           body="$(echo "$annotation" | tail -n +3)"


### PR DESCRIPTION
## :earth_americas: Summary

closes #188

## :package: Proposed Changes

- Implements recommended workaround described in https://github.com/actions/checkout/issues/290 for this known issue

