### PR TITLE
Update CHANGELOGs for release 2026-06-11

### DIFF
--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -92,7 +92,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.3.0"
+version = "0.4.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.0 — 2026-06-11
+
+- Add `--dangerously-skip-results-archive-upload` flag to the sandbox CLI, which skips the post-run results archive upload; requires `--results-url` to point at a real destination and is mutually exclusive with `--results-upload-url` ([#185](https://github.com/wildlife-dynamics/wt/pull/185))
+- Add corresponding `skip_results_archive_upload` parameter to `CloudRunJobsSandboxInvoker`, with eager validation at job-submission time mirroring the sandbox CLI's rules ([#185](https://github.com/wildlife-dynamics/wt/pull/185))
+- `results_upload_url` is now optional on `CloudRunJobsSandboxInvoker` and the sandbox CLI — required only when the results archive upload is not skipped ([#185](https://github.com/wildlife-dynamics/wt/pull/185))
+
 ## v0.3.0 — 2026-05-13
 
 - Add `SandboxInvoker`: downloads a pixi-pack environment tarball, runs the workflow inside the unpacked env, and uploads a results archive to a signed URL. Exposed via the `wt-invokers.sandbox` console entry point as a Docker image ENTRYPOINT ([#164](https://github.com/wildlife-dynamics/wt/pull/164))

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -194,7 +194,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.3.0"
+version = "0.4.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
closes #190 

Release prep for **wt-invokers v0.4.0** (with **wt-invokers-gcp v0.4.0** tagged in lockstep):

- `wt-invokers/CHANGELOG.md`: new v0.4.0 entry covering the `--dangerously-skip-results-archive-upload` feature (#185)
- `wt-invokers/pyproject.toml`: pixi version 0.3.0 → 0.4.0
- `wt-invokers-gcp/pyproject.toml`: pixi version 0.3.0 → 0.4.0

No other packages have changes since their last release. No cascading floor bumps needed — the wt-invokers change is additive and wt-runner does not use the new API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)