### PR TITLE
fix(wt-invokers): follow HTTP redirects when downloading environment tar

### DIFF
--- a/wt-invokers/src/wt_invokers/mixins.py
+++ b/wt-invokers/src/wt_invokers/mixins.py
@@ -230,7 +230,7 @@ async def _download_with_retries(url: str, dest: Path) -> None:
     )
     async def _do_download() -> None:
         async with (
-            httpx.AsyncClient(timeout=_timeout()) as client,
+            httpx.AsyncClient(timeout=_timeout(), follow_redirects=True) as client,
             client.stream("GET", url) as response,
         ):
             if 500 <= response.status_code < 600:

--- a/wt-invokers/tests/conftest.py
+++ b/wt-invokers/tests/conftest.py
@@ -51,6 +51,13 @@ class _UploadHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(500)
             self.end_headers()
             return None
+        # Simulate a GitHub-release-style 302 to a signed asset URL: a
+        # request to /redirect/<name> redirects to /<name>.
+        if self.path.startswith("/redirect/"):
+            self.send_response(302)
+            self.send_header("Location", self.path[len("/redirect") :])
+            self.end_headers()
+            return None
         return super().do_GET()
 
 

--- a/wt-invokers/tests/test_mixins.py
+++ b/wt-invokers/tests/test_mixins.py
@@ -240,6 +240,28 @@ async def test_pre_run_https_download_integration(
 
 
 @pytest.mark.asyncio
+async def test_pre_run_follows_redirect(
+    tmp_path: Path,
+    http_server: tuple[str, Path, dict[str, int]],
+) -> None:
+    """A 302 redirect (as GitHub release URLs return) is followed."""
+    url, directory, _fail = http_server
+    (directory / "env.tar").write_bytes(b"redirected-bytes")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    inv = _make_pixi(work, environment_tar_url=f"{url}/redirect/env.tar")
+
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        patch("wt_invokers.mixins.subprocess.run"),
+    ):
+        await inv._pre_run()
+
+    assert (work / "environment.tar").read_bytes() == b"redirected-bytes"
+
+
+@pytest.mark.asyncio
 async def test_pre_run_retries_on_5xx(
     tmp_path: Path,
     http_server: tuple[str, Path, dict[str, int]],


### PR DESCRIPTION


## :earth_americas: Summary

closes #192 

## :package: Proposed Changes

- The sandbox invoker's _pre_run downloads environment_tar_url from a GitHub release URL, which responds with a 302 redirect to a short-lived signed asset URL. httpx defaults to follow_redirects=False, so the 302 surfaced as an HTTPStatusError and the job crashed before unpacking the environment.
- Set follow_redirects=True on the download client so the redirect is resolved at download time (keeping the signed URL fresh). Add a 302 branch to the test http_server fixture and a regression test that downloads through the redirect end-to-end.

