### PR TITLE
Update CHANGELOGs for release 2026-06-15

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.1 — 2026-06-15
+
+- Rework the generated `test_dashboard_json` snapshot test to mask ephemeral values — UUIDs and tmp-output paths — with a custom matcher, replacing the previous `no_data`/`path_type` field-exclusion approach so nested dashboard JSON snapshots compare robustly ([#184](https://github.com/wildlife-dynamics/wt/pull/184))
+
 ## v0.8.0 — 2026-05-28
 
 - Add `params` choice to the `wt-compiler get <metadata_attribute>` CLI, exposing the workflow's `params.json` schema alongside the existing `rjsf` and `data-connection-property-names` attributes ([#178](https://github.com/wildlife-dynamics/wt/pull/178))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -158,7 +158,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.8.0"
+version = "0.8.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers-gcp/CHANGELOG.md
+++ b/wt-invokers-gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1 — 2026-06-15
+
+- Lockstep release with wt-invokers v0.4.1
+
 ## v0.3.0 — 2026-05-13
 
 - Lockstep release with wt-invokers v0.3.0

--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -92,7 +92,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1 — 2026-06-15
+
+- Follow HTTP redirects when downloading the environment tar, so a GitHub-release-style 302 to a signed asset URL is handled ([#193](https://github.com/wildlife-dynamics/wt/pull/193))
+
 ## v0.4.0 — 2026-06-11
 
 - Add `--dangerously-skip-results-archive-upload` flag to the sandbox CLI, which skips the post-run results archive upload; requires `--results-url` to point at a real destination and is mutually exclusive with `--results-upload-url` ([#185](https://github.com/wildlife-dynamics/wt/pull/185))

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -194,7 +194,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
Release prep for 2026-06-15.

closes #195

## Packages

| Package | Current | New | Reason |
|---------|---------|-----|--------|
| wt-compiler | 0.8.0 | 0.8.1 | Rework generated dashboard-JSON snapshot test to mask ephemeral values via custom matcher (#184) |
| wt-invokers | 0.4.0 | 0.4.1 | Follow HTTP redirects when downloading environment tar (#193) |
| wt-invokers-gcp | 0.4.0 | 0.4.1 | Lockstep release with wt-invokers |

## Changes

- CHANGELOG entries for wt-compiler, wt-invokers, and wt-invokers-gcp
- `[tool.pixi.package]` version bumps for the three packages above

No `default-env-injections.toml` lower-bound changes — neither wt-task nor wt-runner is in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)