### PR TITLE
feat(wt-invokers): require --environment-tar-digest and verify before unpack

### DIFF
--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Breaking:** `--environment-tar-digest sha256:<hex>` is now **required** on the sandbox CLI and as the `environment_tar_digest` keyword argument on `CloudRunJobsSandboxInvoker.run(...)`. The downloaded `environment.tar` is verified against this digest before unpacking; on mismatch the run **fails before unpacking, raising and exiting non-zero** (no `result.json` written), so a tampered or corrupted environment never executes. Callers populating `invoker_kwargs` for wt-runner must now include `environment_tar_digest` ([#191](https://github.com/wildlife-dynamics/wt/issues/191))
+
 ## v0.4.1 — 2026-06-15
 
 - Follow HTTP redirects when downloading the environment tar, so a GitHub-release-style 302 to a signed asset URL is handled ([#193](https://github.com/wildlife-dynamics/wt/pull/193))

--- a/wt-invokers/src/wt_invokers/cloud_run_jobs.py
+++ b/wt-invokers/src/wt_invokers/cloud_run_jobs.py
@@ -24,7 +24,7 @@ except ImportError:
     CLOUD_RUN_AVAILABLE = False
 
 from .abstract import AbstractInvoker
-from .utils import yaml_to_json
+from .utils import validate_environment_tar_digest, yaml_to_json
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +107,7 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
         lithops_config_text: str | None = None,  # noqa: ARG002  # interface compatibility — proxy invoker doesn't run lithops
         *,
         environment_tar_url: str,
+        environment_tar_digest: str,
         results_upload_url: str | None = None,
         skip_results_archive_upload: bool = False,
         job_name: str,
@@ -128,6 +129,10 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
             lithops_config_text: Unused; accepted for interface compatibility
                 with the abstract :meth:`_run` signature.
             environment_tar_url: Signed URL of the pixi-pack environment tarball.
+            environment_tar_digest: Expected sha256 digest of the environment
+                tarball, formatted as ``"sha256:<64 hex chars>"``. Forwarded to
+                the sandbox CLI, which verifies the downloaded tarball against
+                it before unpacking.
             results_upload_url: Signed URL where the results archive should be
                 uploaded after the workflow finishes. Required unless
                 ``skip_results_archive_upload`` is ``True``, in which case it
@@ -142,12 +147,14 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
             region: GCP region (default ``us-central1``).
 
         Raises:
-            ValueError: If ``results_upload_url`` and
-                ``skip_results_archive_upload`` are combined inconsistently.
-                Validation happens eagerly here — mirroring the sandbox CLI's
-                rules — because the job runs asynchronously, so a CLI-level
-                error would otherwise only surface inside the container.
+            ValueError: If ``environment_tar_digest`` is malformed, or if
+                ``results_upload_url`` and ``skip_results_archive_upload`` are
+                combined inconsistently. Validation happens eagerly here —
+                mirroring the sandbox CLI's rules — because the job runs
+                asynchronously, so a CLI-level error would otherwise only
+                surface inside the container.
         """
+        validate_environment_tar_digest(environment_tar_digest)
         if not skip_results_archive_upload and results_upload_url is None:
             raise ValueError(
                 "results_upload_url is required unless skip_results_archive_upload=True"
@@ -177,6 +184,8 @@ class CloudRunJobsSandboxInvoker(AbstractInvoker):
             workflow_run_id,
             "--environment-tar-url",
             environment_tar_url,
+            "--environment-tar-digest",
+            environment_tar_digest,
             "--results-url",
             results_url,
             "--config-json",

--- a/wt-invokers/src/wt_invokers/exceptions.py
+++ b/wt-invokers/src/wt_invokers/exceptions.py
@@ -51,6 +51,26 @@ class InstallationError(InvokerError):
     """
 
 
+class EnvironmentTarDigestError(InvokerError):
+    """Exception raised when the environment tarball fails its integrity check.
+
+    Raised by :class:`~wt_invokers.mixins.PixiUnpackMixin` when the sha256 of
+    the downloaded ``environment.tar`` does not match the expected
+    ``environment_tar_digest``. The mismatch aborts the run before unpacking,
+    so a tampered or corrupted environment never executes.
+
+    Examples:
+        Raising an integrity-check failure:
+
+        >>> raise EnvironmentTarDigestError(
+        ...     "environment.tar integrity check failed: expected x, got y"
+        ... )
+        Traceback (most recent call last):
+            ...
+        wt_invokers.exceptions.EnvironmentTarDigestError: environment.tar integrity check failed: expected x, got y
+    """
+
+
 class PixiUnpackError(InvokerError):
     """Exception raised when the ``pixi-unpack`` subprocess fails.
 

--- a/wt-invokers/src/wt_invokers/mixins.py
+++ b/wt-invokers/src/wt_invokers/mixins.py
@@ -27,6 +27,7 @@ silently drop its hook.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import shutil
 import subprocess
@@ -40,7 +41,7 @@ from urllib.request import url2pathname
 import httpx
 import stamina
 
-from .exceptions import PixiUnpackError
+from .exceptions import EnvironmentTarDigestError, PixiUnpackError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -152,6 +153,31 @@ def archive_results_safely(results_dir: Path, dest: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _sha256_file(path: Path) -> str:
+    """Compute the sha256 digest of a file, streamed in chunks.
+
+    Reads the file in ``TRANSFER_CHUNK_SIZE`` chunks so arbitrarily large
+    tarballs are hashed without being read fully into memory. The returned
+    value is formatted as ``"sha256:<lowercase hex>"`` so it can be compared
+    directly against the ``environment_tar_digest`` produced by the
+    workflow-environment build pipeline.
+
+    Args:
+        path: Path to the file to hash.
+
+    Returns:
+        The digest string ``"sha256:<hexdigest>"``.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(TRANSFER_CHUNK_SIZE)
+            if not chunk:
+                break
+            h.update(chunk)
+    return f"sha256:{h.hexdigest()}"
+
+
 class PixiUnpackMixin:
     """Pre-run hook that downloads and unpacks a pixi-pack environment tarball.
 
@@ -164,6 +190,14 @@ class PixiUnpackMixin:
     Supports ``file://``, ``http://``, and ``https://`` URL schemes for the
     tarball source. HTTP(S) downloads are retried via ``stamina`` on transport
     errors and 5xx responses.
+
+    The (required) ``environment_tar_digest`` run-arg is verified against the
+    sha256 of the downloaded tarball *before* unpacking. On mismatch the hook
+    raises :class:`~wt_invokers.exceptions.EnvironmentTarDigestError` and never
+    runs ``pixi-unpack``, so a tampered or corrupted environment never
+    executes. This mirrors the adjacent pre-run failure mode (a failing
+    ``pixi-unpack`` raises :class:`~wt_invokers.exceptions.PixiUnpackError`):
+    both propagate out of ``run()`` and leave ``"activate_path"`` unset.
     """
 
     # These attributes come from :class:`AbstractInvoker` at runtime; declared
@@ -188,6 +222,12 @@ class PixiUnpackMixin:
                 "environment_tar_url is required -- pass it as a kwarg to run()"
             )
 
+        environment_tar_digest = self.run_args.get("environment_tar_digest")
+        if not environment_tar_digest:
+            raise ValueError(
+                "environment_tar_digest is required -- pass it as a kwarg to run()"
+            )
+
         Path(self.work_dir).mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240  # local mkdir; fast metadata op, no event-loop blocking risk
         tar_path = Path(self.work_dir) / "environment.tar"
 
@@ -199,6 +239,19 @@ class PixiUnpackMixin:
         else:
             raise ValueError(
                 f"Unsupported scheme for environment_tar_url: {parsed.scheme}"
+            )
+
+        # Integrity gate: verify the downloaded tarball against the expected
+        # digest BEFORE unpacking or running anything. On mismatch, raise so the
+        # run fails before unpacking — leaving activate_path unset — exactly like
+        # a failing pixi-unpack below. A tampered or corrupted environment never
+        # executes. Compare case-insensitively so an uppercase-hex digest still
+        # matches our lowercase computed digest.
+        actual_digest = _sha256_file(tar_path)
+        if actual_digest.lower() != environment_tar_digest.lower():
+            raise EnvironmentTarDigestError(
+                f"environment.tar integrity check failed: "
+                f"expected {environment_tar_digest}, got {actual_digest}"
             )
 
         try:

--- a/wt-invokers/src/wt_invokers/sandbox.py
+++ b/wt-invokers/src/wt_invokers/sandbox.py
@@ -34,7 +34,7 @@ from rattler import MatchSpec
 from .abstract import AbstractInvoker
 from .exceptions import InvocationTimeoutError
 from .mixins import PixiUnpackMixin, UploadResultsArchiveMixin
-from .utils import yaml_to_json
+from .utils import validate_environment_tar_digest, yaml_to_json
 
 
 @dataclass
@@ -201,6 +201,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--workflow-run-id", required=True)
     p.add_argument("--environment-tar-url", required=True)
+    p.add_argument(
+        "--environment-tar-digest",
+        required=True,
+        help=(
+            "Expected sha256 digest of the environment tarball, formatted as "
+            "'sha256:<64 hex chars>'. The downloaded environment.tar is verified "
+            "against this before unpacking; on mismatch the run fails before "
+            "unpacking, raising and exiting non-zero (no result.json written)."
+        ),
+    )
     # Effectively required unless --dangerously-skip-results-archive-upload is
     # passed; requiredness is enforced post-parse in main() so the error
     # message can reference the skip flag.
@@ -252,6 +262,7 @@ async def _amain(args: argparse.Namespace) -> int:
         otel_exporter=args.otel_exporter,
         otel_console_exporter_dst=args.otel_console_exporter_dst,
         environment_tar_url=args.environment_tar_url,
+        environment_tar_digest=args.environment_tar_digest,
         results_upload_url=args.results_upload_url,
         skip_results_archive_upload=args.skip_results_archive_upload,
     )
@@ -262,6 +273,10 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point: parse args, run the sandbox invoker, exit with its code."""
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
+    try:
+        validate_environment_tar_digest(args.environment_tar_digest)
+    except ValueError as e:
+        parser.error(str(e))
     if not args.skip_results_archive_upload:
         if args.results_upload_url is None:
             parser.error(

--- a/wt-invokers/src/wt_invokers/utils.py
+++ b/wt-invokers/src/wt_invokers/utils.py
@@ -6,8 +6,53 @@ This module provides utility functions used by various invoker implementations.
 from __future__ import annotations
 
 import json
+import re
 
 import ruamel.yaml
+
+# Expected environment-tar digest format: a ``sha256:`` prefix followed by
+# exactly 64 hexadecimal characters (case-insensitive). This mirrors the
+# digest emitted by the workflow-environment build pipeline (lowercase
+# ``"sha256:" + sha256(environment.tar).hexdigest()``).
+_ENVIRONMENT_TAR_DIGEST_RE = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+
+
+def validate_environment_tar_digest(digest: str) -> None:
+    """Validate the format of an expected ``environment.tar`` sha256 digest.
+
+    The digest must be a literal ``sha256:`` prefix followed by exactly 64
+    hexadecimal characters (case-insensitive), matching the format produced
+    by the workflow-environment build pipeline. This validates *format* only;
+    the actual integrity comparison against the downloaded tarball happens in
+    :class:`~wt_invokers.mixins.PixiUnpackMixin`.
+
+    Args:
+        digest: The expected digest string, e.g. ``"sha256:<64 hex chars>"``.
+
+    Raises:
+        ValueError: If ``digest`` is not a ``sha256:`` prefix followed by
+            exactly 64 hexadecimal characters.
+
+    Examples:
+        A well-formed digest is accepted (returns ``None``):
+
+        >>> validate_environment_tar_digest("sha256:" + "a" * 64)
+
+        Uppercase hex is also accepted:
+
+        >>> validate_environment_tar_digest("sha256:" + "A" * 64)
+
+        A wrong algorithm, missing prefix, or bad hex length is rejected:
+
+        >>> validate_environment_tar_digest("md5:" + "a" * 32)
+        Traceback (most recent call last):
+            ...
+        ValueError: environment_tar_digest must be 'sha256:<64 hex chars>', got: ...
+    """
+    if not _ENVIRONMENT_TAR_DIGEST_RE.match(digest):
+        raise ValueError(
+            f"environment_tar_digest must be 'sha256:<64 hex chars>', got: {digest}"
+        )
 
 
 def yaml_to_json(text: str) -> str:

--- a/wt-invokers/tests/test_cloud_run_jobs.py
+++ b/wt-invokers/tests/test_cloud_run_jobs.py
@@ -16,6 +16,10 @@ from rattler import MatchSpec
 import wt_invokers.cloud_run_jobs as module
 from wt_invokers.cloud_run_jobs import CloudRunJobsSandboxInvoker
 
+# A syntactically valid digest; the proxy validates format and forwards it
+# verbatim to the sandbox CLI, so the exact value is never hashed here.
+_VALID_DIGEST = "sha256:" + "a" * 64
+
 
 @pytest.fixture
 def mock_run_modules(monkeypatch: pytest.MonkeyPatch) -> Any:
@@ -106,6 +110,7 @@ async def test_run_triggers_job_with_correct_args(mock_run_modules: Any) -> None
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url="https://x/env.tar",
+            environment_tar_digest=_VALID_DIGEST,
             results_upload_url="https://x/out",
             job_name="sandbox-job",
             project_id="my-proj",
@@ -142,6 +147,7 @@ async def test_run_defaults_region_to_us_central1(mock_run_modules: Any) -> None
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url="https://x/e.tar",
+            environment_tar_digest=_VALID_DIGEST,
             results_upload_url="https://x/o",
             job_name="j",
             project_id="p",
@@ -189,6 +195,7 @@ async def test_ensure_job_exists_raises_clear_error_on_missing(
                 execution_mode="sequential",
                 mock_io=False,
                 environment_tar_url="https://x/e.tar",
+                environment_tar_digest=_VALID_DIGEST,
                 results_upload_url="https://x/o",
                 job_name="j",
                 project_id="p",
@@ -257,6 +264,7 @@ async def test_run_builds_container_args(mock_run_modules: Any) -> None:
             otel_console_exporter_dst="stdout",
             extra_env={"X": "1"},
             environment_tar_url="https://e/env.tar",
+            environment_tar_digest=_VALID_DIGEST,
             results_upload_url="https://e/out",
             job_name="j",
             project_id="p",
@@ -272,6 +280,10 @@ async def test_run_builds_container_args(mock_run_modules: Any) -> None:
     assert "run-42" in args
     assert "--environment-tar-url" in args
     assert "https://e/env.tar" in args
+    assert "--environment-tar-digest" in args
+    assert _VALID_DIGEST in args
+    # The digest immediately follows its flag in the argv.
+    assert args[args.index("--environment-tar-digest") + 1] == _VALID_DIGEST
     assert "--results-upload-url" in args
     assert "https://e/out" in args
     assert "--results-url" in args
@@ -303,6 +315,7 @@ async def test_run_skip_upload_builds_container_args(mock_run_modules: Any) -> N
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url="https://e/env.tar",
+            environment_tar_digest=_VALID_DIGEST,
             skip_results_archive_upload=True,
             job_name="j",
             project_id="p",
@@ -327,6 +340,7 @@ async def test_run_skip_upload_with_upload_url_raises(mock_run_modules: Any) -> 
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url="https://x/e.tar",
+            environment_tar_digest=_VALID_DIGEST,
             results_upload_url="https://x/o",
             skip_results_archive_upload=True,
             job_name="j",
@@ -348,6 +362,7 @@ async def test_run_missing_upload_url_without_skip_raises(
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url="https://x/e.tar",
+            environment_tar_digest=_VALID_DIGEST,
             job_name="j",
             project_id="p",
         )
@@ -367,7 +382,45 @@ async def test_run_skip_upload_with_default_results_url_raises(
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url="https://x/e.tar",
+            environment_tar_digest=_VALID_DIGEST,
             skip_results_archive_upload=True,
+            job_name="j",
+            project_id="p",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_bad_digest_format_raises_eagerly(mock_run_modules: Any) -> None:
+    """A malformed environment_tar_digest is rejected before the job is submitted."""
+    inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("w>=1.0.0"))
+    with pytest.raises(ValueError, match="environment_tar_digest must be"):
+        await inv.run(
+            workflow_run_id="r",
+            config_text="k: v",
+            results_url="file:///r",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url="https://x/e.tar",
+            environment_tar_digest="not-a-valid-digest",
+            results_upload_url="https://x/o",
+            job_name="j",
+            project_id="p",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_missing_digest_kwarg_raises(mock_run_modules: Any) -> None:
+    """environment_tar_digest is a required keyword-only argument."""
+    inv = CloudRunJobsSandboxInvoker(matchspec=MatchSpec("w>=1.0.0"))
+    with pytest.raises(TypeError):
+        await inv.run(
+            workflow_run_id="r",
+            config_text="k: v",
+            results_url="file:///r",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url="https://x/e.tar",
+            results_upload_url="https://x/o",
             job_name="j",
             project_id="p",
         )

--- a/wt-invokers/tests/test_mixins.py
+++ b/wt-invokers/tests/test_mixins.py
@@ -10,6 +10,7 @@ mock httpx for fine-grained retry behaviour.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import tarfile
@@ -26,7 +27,7 @@ from rattler import MatchSpec
 
 from wt_invokers import mixins
 from wt_invokers.abstract import AbstractInvoker
-from wt_invokers.exceptions import PixiUnpackError
+from wt_invokers.exceptions import EnvironmentTarDigestError, PixiUnpackError
 from wt_invokers.mixins import (
     PixiUnpackMixin,
     RetryableHTTPError,
@@ -94,6 +95,11 @@ class _UploadOnly(UploadResultsArchiveMixin, AbstractInvoker):
         return True
 
 
+def _digest(data: bytes) -> str:
+    """sha256 of ``data`` in the ``sha256:<hex>`` form the mixin compares against."""
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
 def _make_pixi(tmp_path: Path, **run_args: Any) -> _PixiUnpackOnly:
     inv = _PixiUnpackOnly(matchspec=MatchSpec("w>=1.0.0"), work_dir=str(tmp_path))
     inv._run_args.update(run_args)
@@ -149,7 +155,11 @@ async def test_pre_run_missing_env_url_raises(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_pre_run_unsupported_scheme(tmp_path: Path) -> None:
-    inv = _make_pixi(tmp_path, environment_tar_url="s3://bucket/env.tar")
+    inv = _make_pixi(
+        tmp_path,
+        environment_tar_url="s3://bucket/env.tar",
+        environment_tar_digest=_digest(b"x"),
+    )
     with (
         patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
         pytest.raises(ValueError, match="Unsupported scheme"),
@@ -170,6 +180,7 @@ async def test_pre_run_file_url_copies_and_unpacks(tmp_path: Path) -> None:
     inv = _make_pixi(
         work,
         environment_tar_url=f"file://{source_tar}",
+        environment_tar_digest=_digest(b"fake-tarball"),
     )
 
     with (
@@ -199,7 +210,11 @@ async def test_pre_run_pixi_unpack_failure_wraps_in_domain_exception(
     """
     source_tar = tmp_path / "env.tar"
     source_tar.write_bytes(b"bad")
-    inv = _make_pixi(tmp_path, environment_tar_url=f"file://{source_tar}")
+    inv = _make_pixi(
+        tmp_path,
+        environment_tar_url=f"file://{source_tar}",
+        environment_tar_digest=_digest(b"bad"),
+    )
     underlying = subprocess.CalledProcessError(
         2, "pixi-unpack", output=b"out", stderr=b"err"
     )
@@ -227,7 +242,11 @@ async def test_pre_run_https_download_integration(
 
     work = tmp_path / "work"
     work.mkdir()
-    inv = _make_pixi(work, environment_tar_url=f"{url}/env.tar")
+    inv = _make_pixi(
+        work,
+        environment_tar_url=f"{url}/env.tar",
+        environment_tar_digest=_digest(b"streamed-bytes"),
+    )
 
     with (
         patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
@@ -250,7 +269,11 @@ async def test_pre_run_follows_redirect(
 
     work = tmp_path / "work"
     work.mkdir()
-    inv = _make_pixi(work, environment_tar_url=f"{url}/redirect/env.tar")
+    inv = _make_pixi(
+        work,
+        environment_tar_url=f"{url}/redirect/env.tar",
+        environment_tar_digest=_digest(b"redirected-bytes"),
+    )
 
     with (
         patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
@@ -272,7 +295,11 @@ async def test_pre_run_retries_on_5xx(
 
     work = tmp_path / "work"
     work.mkdir()
-    inv = _make_pixi(work, environment_tar_url=f"{url}/env.tar")
+    inv = _make_pixi(
+        work,
+        environment_tar_url=f"{url}/env.tar",
+        environment_tar_digest=_digest(b"bytes-v1"),
+    )
 
     with (
         patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
@@ -286,7 +313,11 @@ async def test_pre_run_retries_on_5xx(
 @pytest.mark.asyncio
 async def test_pre_run_download_does_not_retry_on_4xx(tmp_path: Path) -> None:
     """A 4xx response surfaces immediately as HTTPStatusError (no retry)."""
-    inv = _make_pixi(tmp_path, environment_tar_url="https://example.com/env.tar")
+    inv = _make_pixi(
+        tmp_path,
+        environment_tar_url="https://example.com/env.tar",
+        environment_tar_digest=_digest(b"x"),
+    )
 
     response = httpx.Response(
         404,
@@ -322,6 +353,121 @@ async def test_pre_run_download_does_not_retry_on_4xx(tmp_path: Path) -> None:
         pytest.raises(httpx.HTTPStatusError),
     ):
         await inv._pre_run()
+
+
+# ---------------------------------------------------------------------------
+# PixiUnpackMixin — environment.tar integrity check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_run_missing_digest_raises(tmp_path: Path) -> None:
+    """environment_tar_digest is required -- absence raises before download."""
+    source_tar = tmp_path / "env.tar"
+    source_tar.write_bytes(b"fake-tarball")
+    inv = _make_pixi(tmp_path, environment_tar_url=f"file://{source_tar}")
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        pytest.raises(ValueError, match="environment_tar_digest is required"),
+    ):
+        await inv._pre_run()
+
+
+@pytest.mark.asyncio
+async def test_pre_run_digest_mismatch_raises_file(tmp_path: Path) -> None:
+    """A wrong digest raises and never runs pixi-unpack (file:// path)."""
+    source = tmp_path / "source"
+    source.mkdir()
+    source_tar = source / "env.tar"
+    source_tar.write_bytes(b"fake-tarball")
+
+    work = tmp_path / "work"
+    work.mkdir()
+
+    wrong_digest = _digest(b"different-bytes")
+    inv = _make_pixi(
+        work,
+        environment_tar_url=f"file://{source_tar}",
+        environment_tar_digest=wrong_digest,
+    )
+
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        patch("wt_invokers.mixins.subprocess.run") as mock_run,
+        pytest.raises(
+            EnvironmentTarDigestError,
+            match=r"environment\.tar integrity check failed",
+        ),
+    ):
+        await inv._pre_run()
+
+    # The tarball was downloaded, but unpack was skipped and no env activated.
+    assert (work / "environment.tar").read_bytes() == b"fake-tarball"
+    mock_run.assert_not_called()
+    assert "activate_path" not in inv.run_state
+
+
+@pytest.mark.asyncio
+async def test_pre_run_digest_mismatch_raises_http(
+    tmp_path: Path,
+    http_server: tuple[str, Path, dict[str, int]],
+) -> None:
+    """A wrong digest raises and never runs pixi-unpack (http path)."""
+    url, directory, _fail = http_server
+    (directory / "env.tar").write_bytes(b"streamed-bytes")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    inv = _make_pixi(
+        work,
+        environment_tar_url=f"{url}/env.tar",
+        environment_tar_digest=_digest(b"not-the-bytes"),
+    )
+
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        patch("wt_invokers.mixins.subprocess.run") as mock_run,
+        pytest.raises(
+            EnvironmentTarDigestError,
+            match=r"environment\.tar integrity check failed",
+        ),
+    ):
+        await inv._pre_run()
+
+    mock_run.assert_not_called()
+    assert "activate_path" not in inv.run_state
+
+
+@pytest.mark.asyncio
+async def test_pre_run_digest_match_is_case_insensitive(tmp_path: Path) -> None:
+    """An uppercase-hex digest still matches the lowercase computed digest."""
+    source_tar = tmp_path / "env.tar"
+    source_tar.write_bytes(b"fake-tarball")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    inv = _make_pixi(
+        work,
+        environment_tar_url=f"file://{source_tar}",
+        environment_tar_digest=_digest(b"fake-tarball").upper(),
+    )
+
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        patch("wt_invokers.mixins.subprocess.run") as mock_run,
+    ):
+        await inv._pre_run()
+
+    mock_run.assert_called_once()
+    assert inv.run_state["activate_path"] == str(work / "activate.sh")
+
+
+def test_sha256_file_matches_hashlib(tmp_path: Path) -> None:
+    """_sha256_file streams the file and returns the sha256:<hex> form."""
+    data = b"some-environment-tarball-bytes" * 1000
+    f = tmp_path / "env.tar"
+    f.write_bytes(data)
+    assert mixins._sha256_file(f) == f"sha256:{hashlib.sha256(data).hexdigest()}"
 
 
 # ---------------------------------------------------------------------------
@@ -838,7 +984,11 @@ async def test_pre_run_file_url_with_space_in_path(tmp_path: Path) -> None:
     # urlparse("file:///tmp/src%20with%20space/env.tar").path keeps the
     # percent-encoded form; without url2pathname, shutil.copy2 would fail.
     url = f"file://{str(source_tar).replace(' ', '%20')}"
-    inv = _make_pixi(work, environment_tar_url=url)
+    inv = _make_pixi(
+        work,
+        environment_tar_url=url,
+        environment_tar_digest=_digest(b"bytes"),
+    )
 
     with (
         patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),

--- a/wt-invokers/tests/test_sandbox.py
+++ b/wt-invokers/tests/test_sandbox.py
@@ -8,6 +8,7 @@ with all external calls mocked.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import sys
@@ -17,11 +18,20 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rattler import MatchSpec
 
-from wt_invokers.exceptions import InvocationTimeoutError
+from wt_invokers.exceptions import EnvironmentTarDigestError, InvocationTimeoutError
 from wt_invokers.sandbox import SandboxInvoker, _build_arg_parser, main
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _digest(data: bytes) -> str:
+    """sha256 of ``data`` in the ``sha256:<hex>`` form the invoker expects."""
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+# A syntactically valid digest for CLI tests where the value is never hashed.
+_VALID_DIGEST = "sha256:" + "a" * 64
 
 
 def test_initialization_default_work_dir() -> None:
@@ -303,6 +313,7 @@ async def test_end_to_end_lifecycle_with_mocked_externals(tmp_path: Path) -> Non
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url=f"file://{source_tar}",
+            environment_tar_digest=_digest(b"fake"),
             results_upload_url=f"file://{upload_dest}",
         )
         exit_code = await inv.wait()
@@ -341,6 +352,7 @@ async def test_end_to_end_lifecycle_with_skip_upload(tmp_path: Path) -> None:
             execution_mode="sequential",
             mock_io=False,
             environment_tar_url=f"file://{source_tar}",
+            environment_tar_digest=_digest(b"fake"),
             skip_results_archive_upload=True,
         )
         exit_code = await inv.wait()
@@ -348,6 +360,55 @@ async def test_end_to_end_lifecycle_with_skip_upload(tmp_path: Path) -> None:
     assert exit_code == 0
     # No upload artifact was created anywhere under tmp_path.
     assert not list(tmp_path.rglob("*.tar.gz"))  # noqa: ASYNC240  # test-only local FS scan; no event loop at stake
+    assert inv.is_running is False
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_digest_mismatch_raises_before_unpack(tmp_path: Path) -> None:
+    """A digest mismatch fails before unpack.
+
+    ``run()`` raises :class:`EnvironmentTarDigestError`; pixi-unpack and the
+    workflow ``Popen`` never run, no ``result.json`` is written, nothing is
+    uploaded, and the invoker is reset to the IDLE state.
+    """
+    source_tar = tmp_path / "env.tar"
+    source_tar.write_bytes(b"fake")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    upload_dest = tmp_path / "out.tar.gz"
+
+    inv = SandboxInvoker(
+        matchspec=MatchSpec("my-workflow>=1.0.0"),
+        work_dir=str(tmp_path / "work"),
+    )
+
+    with (
+        patch("wt_invokers.mixins.shutil.which", return_value="/usr/bin/pixi-unpack"),
+        patch("wt_invokers.mixins.subprocess.run") as mock_unpack,
+        patch("wt_invokers.sandbox.subprocess.Popen") as mock_popen,
+        pytest.raises(
+            EnvironmentTarDigestError,
+            match=r"environment\.tar integrity check failed",
+        ),
+    ):
+        await inv.run(
+            workflow_run_id="r1",
+            config_text="k: v",
+            results_url=f"file://{results_dir}",
+            execution_mode="sequential",
+            mock_io=False,
+            environment_tar_url=f"file://{source_tar}",
+            environment_tar_digest=_digest(b"WRONG"),
+            results_upload_url=f"file://{upload_dest}",
+        )
+
+    # Neither pixi-unpack nor the workflow process ran.
+    mock_unpack.assert_not_called()
+    mock_popen.assert_not_called()
+    # No result.json was written and nothing was uploaded.
+    assert not (results_dir / "result.json").exists()
+    assert not upload_dest.exists()
+    # The invoker was reset to IDLE.
     assert inv.is_running is False
 
 
@@ -388,6 +449,8 @@ def _cli_args_without_upload_url() -> list[str]:
         "r",
         "--environment-tar-url",
         "https://x/e.tar",
+        "--environment-tar-digest",
+        _VALID_DIGEST,
         "--config-json",
         "{}",
     ]
@@ -403,6 +466,8 @@ def test_cli_parses_required_args() -> None:
             "r1",
             "--environment-tar-url",
             "https://x/env.tar",
+            "--environment-tar-digest",
+            _VALID_DIGEST,
             "--results-upload-url",
             "https://x/out",
             "--config-json",
@@ -413,6 +478,7 @@ def test_cli_parses_required_args() -> None:
     assert args.execution_mode == "sequential"
     assert args.mock_io is False
     assert args.results_url == "file:///results"
+    assert args.environment_tar_digest == _VALID_DIGEST
 
 
 def test_cli_mock_io_flag() -> None:
@@ -425,6 +491,8 @@ def test_cli_mock_io_flag() -> None:
             "r",
             "--environment-tar-url",
             "https://x/e.tar",
+            "--environment-tar-digest",
+            _VALID_DIGEST,
             "--results-upload-url",
             "https://x/o",
             "--config-json",
@@ -444,6 +512,56 @@ def test_cli_help_exits_zero() -> None:
 def test_cli_missing_required_args_exits() -> None:
     with pytest.raises(SystemExit) as exc:
         main([])
+    assert exc.value.code != 0
+
+
+def test_cli_missing_environment_tar_digest_exits() -> None:
+    """--environment-tar-digest is required on the sandbox CLI."""
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "--matchspec",
+                "w>=1.0.0",
+                "--workflow-run-id",
+                "r",
+                "--environment-tar-url",
+                "https://x/e.tar",
+                "--results-upload-url",
+                "https://x/o",
+                "--config-json",
+                "{}",
+            ]
+        )
+    assert exc.value.code != 0
+
+
+@pytest.mark.parametrize(
+    "bad_digest",
+    [
+        pytest.param("not-a-digest", id="no-prefix"),
+        pytest.param("md5:" + "a" * 32, id="wrong-algorithm"),
+        pytest.param("sha256:" + "a" * 10, id="bad-hex-length"),
+    ],
+)
+def test_cli_bad_digest_format_exits(bad_digest: str) -> None:
+    """A malformed --environment-tar-digest funnels to parser.error (SystemExit)."""
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "--matchspec",
+                "w>=1.0.0",
+                "--workflow-run-id",
+                "r",
+                "--environment-tar-url",
+                "https://x/e.tar",
+                "--environment-tar-digest",
+                bad_digest,
+                "--results-upload-url",
+                "https://x/o",
+                "--config-json",
+                "{}",
+            ]
+        )
     assert exc.value.code != 0
 
 
@@ -470,6 +588,8 @@ def test_cli_main_invokes_run_and_wait(tmp_path: Path) -> None:
                 "r1",
                 "--environment-tar-url",
                 f"file://{tmp_path}/env.tar",
+                "--environment-tar-digest",
+                _VALID_DIGEST,
                 "--results-upload-url",
                 f"file://{tmp_path}/out.tar.gz",
                 "--results-url",
@@ -483,6 +603,7 @@ def test_cli_main_invokes_run_and_wait(tmp_path: Path) -> None:
     assert called["waited"] is True
     assert called["run_kwargs"]["workflow_run_id"] == "r1"
     assert called["run_kwargs"]["environment_tar_url"] == f"file://{tmp_path}/env.tar"
+    assert called["run_kwargs"]["environment_tar_digest"] == _VALID_DIGEST
     assert called["run_kwargs"]["results_upload_url"] == f"file://{tmp_path}/out.tar.gz"
     assert called["run_kwargs"]["skip_results_archive_upload"] is False
 

--- a/wt-invokers/tests/test_utils.py
+++ b/wt-invokers/tests/test_utils.py
@@ -10,7 +10,7 @@ import json
 
 import pytest
 
-from wt_invokers.utils import yaml_to_json
+from wt_invokers.utils import validate_environment_tar_digest, yaml_to_json
 
 
 def test_yaml_to_json_simple() -> None:
@@ -185,3 +185,41 @@ def test_yaml_to_json_numeric_keys() -> None:
     # YAML treats numeric keys as integers, which become strings in JSON
     assert str(2023) in json_str or 2023 in data
     assert str(42) in json_str or 42 in data
+
+
+# ---------------------------------------------------------------------------
+# validate_environment_tar_digest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [
+        pytest.param("sha256:" + "a" * 64, id="lowercase-hex"),
+        pytest.param("sha256:" + "A" * 64, id="uppercase-hex"),
+        pytest.param("sha256:" + "0123456789abcdef" * 4, id="mixed-hex"),
+    ],
+)
+def test_validate_environment_tar_digest_accepts_valid(digest: str) -> None:
+    """A sha256:<64 hex> digest (any case) is accepted: no exception is raised."""
+    validate_environment_tar_digest(digest)
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [
+        pytest.param("a" * 64, id="missing-prefix"),
+        pytest.param("md5:" + "a" * 32, id="wrong-algorithm-md5"),
+        pytest.param("sha512:" + "a" * 128, id="wrong-algorithm-sha512"),
+        pytest.param("sha256:" + "a" * 63, id="too-few-hex"),
+        pytest.param("sha256:" + "a" * 65, id="too-many-hex"),
+        pytest.param("sha256:" + "g" * 64, id="non-hex-chars"),
+        pytest.param("sha256:", id="empty-hex"),
+        pytest.param("", id="empty-string"),
+        pytest.param("SHA256:" + "a" * 64, id="uppercase-prefix"),
+    ],
+)
+def test_validate_environment_tar_digest_rejects_invalid(digest: str) -> None:
+    """Anything that is not sha256:<64 hex chars> raises ValueError."""
+    with pytest.raises(ValueError, match="environment_tar_digest must be"):
+        validate_environment_tar_digest(digest)


### PR DESCRIPTION
## :earth_americas: Summary

closes #191 

## :package: Proposed Changes

Add a mandatory sha256 integrity check on the sandbox invoker so a tampered or corrupted environment.tar never executes (closes #191).

- utils: add validate_environment_tar_digest() enforcing the sha256:<64 hex>
  format, shared by the sandbox CLI and CloudRunJobsSandboxInvoker
- exceptions: add EnvironmentTarDigestError(InvokerError)
- mixins: PixiUnpackMixin now requires environment_tar_digest and verifies the downloaded tarball's sha256 before pixi-unpack; on mismatch it raises EnvironmentTarDigestError before unpacking (activate_path left unset), mirroring the adjacent PixiUnpackError pre-run failure mode
- sandbox: add the required --environment-tar-digest CLI flag with format validation and forward it through to the invoker
- cloud_run_jobs: add the required environment_tar_digest kwarg with eager format validation and forward it to the sandbox CLI container args

Both upload and --dangerously-skip-results-archive-upload modes behave identically: the run fails before unpacking, raising and exiting non-zero with no result.json written. The deployment detects failure via the exit code / Cloud Run execution status, the same signal it already needs for OOMs, segfaults, and pixi-unpack failures.

BREAKING CHANGE: --environment-tar-digest is now required on the sandbox CLI and environment_tar_digest is a required kwarg on CloudRunJobsSandboxInvoker.run(). Callers populating invoker_kwargs for wt-runner must now include environment_tar_digest.
