### PR TITLE
Update CHANGELOGs for release 2026-06-18

### DIFF
--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -92,7 +92,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.4.1"
+version = "0.5.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## v0.5.0 — 2026-06-18
 
-- **Breaking:** `--environment-tar-digest sha256:<hex>` is now **required** on the sandbox CLI and as the `environment_tar_digest` keyword argument on `CloudRunJobsSandboxInvoker.run(...)`. The downloaded `environment.tar` is verified against this digest before unpacking; on mismatch the run **fails before unpacking, raising and exiting non-zero** (no `result.json` written), so a tampered or corrupted environment never executes. Callers populating `invoker_kwargs` for wt-runner must now include `environment_tar_digest` ([#191](https://github.com/wildlife-dynamics/wt/issues/191))
+- **Breaking:** `--environment-tar-digest sha256:<hex>` is now **required** on the sandbox CLI and as the `environment_tar_digest` keyword argument on `CloudRunJobsSandboxInvoker.run(...)`. The downloaded `environment.tar` is verified against this digest before unpacking; on mismatch the run **fails before unpacking, raising and exiting non-zero** (no `result.json` written), so a tampered or corrupted environment never executes. Callers populating `invoker_kwargs` for wt-runner must now include `environment_tar_digest` ([#196](https://github.com/wildlife-dynamics/wt/pull/196))
 
 ## v0.4.1 — 2026-06-15
 

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -194,7 +194,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.4.1"
+version = "0.5.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
closes #198

Release prep for 2026-06-18.

## Packages

| Package | Current | New | Reason |
|---------|---------|-----|--------|
| wt-invokers | 0.4.1 | 0.5.0 | Breaking: `--environment-tar-digest` now required, verified before unpack (#196) |
| wt-invokers-gcp | 0.4.1 | 0.5.0 | Lockstep metapackage release with wt-invokers |

## Changes
- `wt-invokers/CHANGELOG.md` — add `v0.5.0` entry
- `wt-invokers/pyproject.toml` — pixi version `0.4.1` → `0.5.0`
- `wt-invokers-gcp/pyproject.toml` — pixi version `0.4.1` → `0.5.0`

Tags (`wt-invokers/v0.5.0`, `wt-invokers-gcp/v0.5.0`) will be created and pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)