### PR TITLE
fix(wt-compiler): allow custom channels without hardcoding the name

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow custom (e.g. prefix.dev) conda channels without hardcoding them in an allowlist: explicit channel URLs in `requirements:` now pass through generically and are emitted into the generated `pixi.toml` workspace channels, while unknown bare channel names still raise to guard against typos ([#203](https://github.com/wildlife-dynamics/wt/issues/203))
+
 ## v0.8.1 — 2026-06-15
 
 - Rework the generated `test_dashboard_json` snapshot test to mask ephemeral values — UUIDs and tmp-output paths — with a custom matcher, replacing the previous `no_data`/`path_type` field-exclusion approach so nested dashboard JSON snapshots compare robustly ([#184](https://github.com/wildlife-dynamics/wt/pull/184))

--- a/wt-compiler/src/wt_compiler/compiler.py
+++ b/wt-compiler/src/wt_compiler/compiler.py
@@ -657,6 +657,17 @@ class DagCompiler(BaseModel):
             channels.append(CUSTOM_LOCAL_CHANNEL.base_url)
         if any(r.channel.base_url == CUSTOM_RELEASE_CHANNEL.base_url for r in conda_reqs):
             channels.append(CUSTOM_RELEASE_CHANNEL.base_url)
+        # Append any custom (e.g. prefix.dev) channel base_urls from requirements that
+        # aren't already listed and aren't one of the standard channels added below, so
+        # the runtime pixi solve can find packages from those channels (#203).
+        standard_base_urls = {
+            RELEASE_CHANNEL.base_url,
+            CONDA_FORGE_CHANNEL.base_url,
+            MICROSOFT_CHANNEL.base_url,
+        }
+        for r in conda_reqs:
+            if r.channel.base_url not in channels and r.channel.base_url not in standard_base_urls:
+                channels.append(r.channel.base_url)
         # Always add standard channels at the end
         # Note: name can be None for custom channels but not for these standard channels
         assert CONDA_FORGE_CHANNEL.name is not None  # noqa: S101  # type narrowing for mypy

--- a/wt-compiler/src/wt_compiler/requirements.py
+++ b/wt-compiler/src/wt_compiler/requirements.py
@@ -51,30 +51,55 @@ PLATFORMS: list[Platform] = [
 
 
 def _channel_from_str(value: str) -> Channel:
-    """Convert a string to a Channel object."""
+    """Convert a string to a Channel object.
+
+    Known channel names and base URLs resolve to their preconfigured
+    :data:`CHANNELS` shortcut. Any other explicit channel URL (one with a
+    URL scheme) is parsed directly into a :class:`Channel`, so custom
+    channels need not be hardcoded. A bare name that is neither a known
+    shortcut nor a URL raises ``ValueError`` to guard against typos.
+
+    Examples:
+        A known shortcut resolves to its preconfigured channel:
+
+        >>> _channel_from_str("conda-forge").name
+        'conda-forge'
+
+        An explicit custom channel URL passes through generically:
+
+        >>> _channel_from_str("https://repo.prefix.dev/ecoscope-workflows-gcf/").name
+        'ecoscope-workflows-gcf'
+    """
     for channel in CHANNELS:
         # TODO(cisaacstern): base_url equality check can be stymied by presence or absence
         # of trailing slash on the base_url. Sanitize the base_url to prevent this issue.
         if channel.name == value or channel.base_url == value:
             return channel
-    raise ValueError(f"Unknown channel {value}; only {CHANNELS} are supported")
+    if urlparse(value).scheme:
+        return Channel(value)
+    raise ValueError(
+        f"Unknown channel {value}; expected an explicit channel URL or one of the "
+        f"known channel shortcuts {CHANNELS}"
+    )
 
 
 def _serialize_channel(value: Channel | str) -> str:
-    """Serialize a Channel object to a string."""
+    """Serialize a Channel object to a string.
+
+    A channel is serialized as its bare ``name`` only when that name
+    round-trips to the same ``base_url`` under rattler's default channel
+    alias (``conda.anaconda.org``); otherwise it is serialized as its
+    explicit ``base_url`` so it reconstructs unambiguously. This keeps
+    standard channels (e.g. ``conda-forge``, ``microsoft``) compact while
+    letting prefix.dev, ``file://``, and other custom channels round-trip.
+    """
     # Handle strings that might have been stored in defaults
     if isinstance(value, str):
         return value
-    if value in [
-        LOCAL_CHANNEL,
-        RELEASE_CHANNEL,
-        CUSTOM_LOCAL_CHANNEL,
-        CUSTOM_RELEASE_CHANNEL,
-        WT_LOCAL_CHANNEL,
-    ]:
-        return value.base_url
     assert value.name is not None, f"Expected name to be set for {value}"  # noqa: S101  # type narrowing for mypy
-    return value.name
+    if Channel(value.name).base_url == value.base_url:
+        return value.name
+    return value.base_url
 
 
 ChannelType = Annotated[
@@ -136,8 +161,10 @@ def _namelessmatchspec_from_dict(
 ) -> NamelessMatchSpec:
     """Create a NamelessMatchSpec from a dictionary with version and channel.
 
-    The channel can be either a channel name or a base_url.
-    Raises ValueError if the channel is not recognized.
+    The channel can be either a known channel name or an explicit channel
+    URL. Bare names are resolved via :func:`_channel_from_str` (which still
+    rejects unknown bare names to guard against typos); explicit URLs pass
+    through generically, so custom channels need not be hardcoded.
 
     Args:
         value: Dictionary with 'version' and 'channel' keys
@@ -147,7 +174,7 @@ def _namelessmatchspec_from_dict(
 
     Raises:
         AssertionError: If 'version' or 'channel' keys are missing
-        ValueError: If the channel is not recognized
+        ValueError: If the channel is a bare name that is not a known shortcut
 
     Examples:
         >>> value = {
@@ -173,6 +200,18 @@ def _namelessmatchspec_from_dict(
         'ecoscope-workflows'
         >>> nms_from_channel_name.channel.base_url
         'https://repo.prefix.dev/ecoscope-workflows/'
+
+        A custom channel URL passes through without being hardcoded:
+
+        >>> custom = {
+        ...     "version": ">=1.0",
+        ...     "channel": "https://repo.prefix.dev/ecoscope-workflows-gcf/",
+        ... }
+        >>> nms_custom = _namelessmatchspec_from_dict(custom)
+        >>> nms_custom.version
+        '>=1.0'
+        >>> nms_custom.channel.base_url
+        'https://repo.prefix.dev/ecoscope-workflows-gcf/'
     """
     assert "version" in value, f"Expected 'version' key in {value}"  # noqa: S101  # input shape invariant
     assert "channel" in value, f"Expected 'channel' key in {value}"  # noqa: S101  # input shape invariant
@@ -180,11 +219,8 @@ def _namelessmatchspec_from_dict(
         _base_url = _channel_from_str(value["channel"]).base_url
     else:
         _base_url = value["channel"]
-    channel = next((c.base_url for c in CHANNELS if c.base_url == _base_url), None)
-    if not channel:
-        raise ValueError(f"Unknown channel {value['channel']}; only {CHANNELS} are supported")
     foo_pkg = "foo"  # placeholder to use from_match_spec constructor
-    m = MatchSpec(f"{channel}::{foo_pkg} {value['version']}")
+    m = MatchSpec(f"{_base_url}::{foo_pkg} {value['version']}")
     return NamelessMatchSpec.from_match_spec(m)
 
 

--- a/wt-compiler/tests/test_compiler.py
+++ b/wt-compiler/tests/test_compiler.py
@@ -248,6 +248,27 @@ class TestDagCompiler:
         assert "test-all" in pixi_toml.feature["test"].tasks
         assert "playwright-install" in pixi_toml.feature["test"].tasks
 
+    def test_get_pixi_toml_with_custom_channel(self, merged_default_feature):
+        """A custom (prefix.dev) channel surfaces in workspace channels and the dep (#203)."""
+        custom_channel = "https://repo.prefix.dev/ecoscope-workflows-gcf/"
+        spec = Spec(
+            id="custom_channel_workflow",
+            requirements=[
+                SpecRequirement(name="custom-pkg", version=">=1.0", channel=custom_channel),
+            ],
+            workflow=[],
+        )
+        compiler = DagCompiler(spec=spec)
+        pixi_toml = compiler.get_pixi_toml(merged_default_feature=merged_default_feature)
+
+        # The custom channel is listed in the workspace channels (not just the
+        # hardcoded standard channels), so the runtime pixi solve can find it.
+        assert custom_channel in [c.base_url for c in pixi_toml.workspace.channels]
+
+        # The dependency entry references the custom channel.
+        assert "custom-pkg" in pixi_toml.dependencies
+        assert pixi_toml.dependencies["custom-pkg"].channel.base_url == custom_channel
+
     def test_get_pixi_toml_with_pypi_deps(self, merged_default_feature):
         """Test pixi.toml generation with mixed conda and pypi requirements."""
         spec = Spec(

--- a/wt-compiler/tests/test_requirements.py
+++ b/wt-compiler/tests/test_requirements.py
@@ -4,10 +4,20 @@
 import importlib
 
 import pytest
-from rattler import NamelessMatchSpec
+from rattler import Channel, NamelessMatchSpec
 
 import wt_compiler.requirements as req_mod
-from wt_compiler.requirements import _serialize_namelessmatchspec
+from wt_compiler.requirements import (
+    CONDA_FORGE_CHANNEL,
+    MICROSOFT_CHANNEL,
+    RELEASE_CHANNEL,
+    _channel_from_str,
+    _namelessmatchspec_from_dict,
+    _serialize_channel,
+    _serialize_namelessmatchspec,
+)
+
+CUSTOM_CHANNEL_URL = "https://repo.prefix.dev/ecoscope-workflows-gcf/"
 
 
 class TestWtLocalChannel:
@@ -70,3 +80,68 @@ def test_serialize_namelessmatchspec_version(spec: str, expected: dict[str, str]
     rejected at solve time (``No candidates were found for pandas ==none``).
     """
     assert _serialize_namelessmatchspec(NamelessMatchSpec(spec)) == expected
+
+
+class TestChannelFromStr:
+    """Tests for _channel_from_str shortcut resolution and URL pass-through."""
+
+    def test_custom_url_passes_through(self) -> None:
+        """A custom prefix.dev channel URL parses generically, no allowlist needed."""
+        channel = _channel_from_str(CUSTOM_CHANNEL_URL)
+
+        assert channel.name == "ecoscope-workflows-gcf"
+        assert channel.base_url == CUSTOM_CHANNEL_URL
+
+    def test_unknown_bare_name_raises(self) -> None:
+        """A bare name that is neither a known shortcut nor a URL still raises."""
+        with pytest.raises(ValueError, match="Unknown channel"):
+            _channel_from_str("not-a-real-channel")
+
+    def test_known_name_resolves_to_shortcut(self) -> None:
+        """A known channel name resolves to its preconfigured shortcut."""
+        channel = _channel_from_str("ecoscope-workflows")
+
+        assert channel.base_url == RELEASE_CHANNEL.base_url
+
+    def test_known_base_url_resolves_to_shortcut(self) -> None:
+        """A known channel base_url resolves to its preconfigured shortcut."""
+        channel = _channel_from_str(RELEASE_CHANNEL.base_url)
+
+        assert channel.base_url == RELEASE_CHANNEL.base_url
+
+
+@pytest.mark.parametrize(
+    ("channel", "expected"),
+    [
+        (CONDA_FORGE_CHANNEL, "conda-forge"),
+        (MICROSOFT_CHANNEL, "microsoft"),
+        (RELEASE_CHANNEL, "https://repo.prefix.dev/ecoscope-workflows/"),
+        (Channel(CUSTOM_CHANNEL_URL), CUSTOM_CHANNEL_URL),
+    ],
+)
+def test_serialize_channel(channel: Channel, expected: str) -> None:
+    """Channels that round-trip from name serialize as the name, else as base_url.
+
+    ``conda-forge`` / ``microsoft`` reconstruct from their bare name under
+    rattler's default alias, so they serialize compactly. prefix.dev channels
+    (standard or custom) do not, so they serialize as their base_url to
+    round-trip unambiguously.
+    """
+    assert _serialize_channel(channel) == expected
+
+
+def test_serialize_channel_passthrough_str() -> None:
+    """A string value (e.g. stored in defaults) passes through unchanged."""
+    assert _serialize_channel("conda-forge") == "conda-forge"
+
+
+class TestNamelessMatchSpecFromDictCustomChannel:
+    """Tests for _namelessmatchspec_from_dict with custom (non-allowlisted) channels."""
+
+    def test_custom_channel_url_accepted(self) -> None:
+        """A custom prefix.dev channel URL is accepted and preserves version + channel."""
+        value = {"version": ">=1.0", "channel": CUSTOM_CHANNEL_URL}
+        nms = _namelessmatchspec_from_dict(value)
+
+        assert nms.version == ">=1.0"
+        assert nms.channel.base_url == CUSTOM_CHANNEL_URL


### PR DESCRIPTION
## :earth_americas: Summary

closes #203


## :package: Proposed Changes

Previously the hardcoded CHANNELS list acted as an allowlist, so a requirement on a custom prefix.dev channel (e.g.
https://repo.prefix.dev/ecoscope-workflows-gcf/) was rejected with "Unknown channel ...; only [...] are supported".

Channel handling is now generic:
- `_channel_from_str` keeps the CHANNELS list as shortcuts, but any explicit channel URL (one with a URL scheme) now passes through via `Channel(value)`. Bare names that are neither a known shortcut nor a URL still raise, preserving typo protection.
- `_serialize_channel` replaces the hardcoded "serialize-as-base_url" list with a generic round-trip rule: serialize as the bare name iff `Channel(name).base_url` reconstructs the channel, else as base_url. This reproduces today's output for all known channels and lets custom URL channels round-trip.
- `_namelessmatchspec_from_dict` drops its CHANNELS membership check and builds the matchspec directly from the resolved base_url.
- `get_pixi_toml` now emits custom requirement channels into the workspace channel list so the runtime pixi solve can find the package.


