### PR TITLE
Update CHANGELOGs for release 2026-06-26

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.2 — 2026-06-26
 
 - Allow custom (e.g. prefix.dev) conda channels without hardcoding them in an allowlist: explicit channel URLs in `requirements:` now pass through generically and are emitted into the generated `pixi.toml` workspace channels, while unknown bare channel names still raise to guard against typos ([#203](https://github.com/wildlife-dynamics/wt/issues/203))
 

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -158,7 +158,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.8.1"
+version = "0.8.2"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
Release prep for 2026-06-26.

closes #206

## Packages

| Package | Current | New | Reason |
|---------|---------|-----|--------|
| wt-compiler | 0.8.1 | 0.8.2 | Allow custom (e.g. prefix.dev) conda channels in `requirements:` without a hardcoded allowlist ([#203](https://github.com/wildlife-dynamics/wt/issues/203) / #204) |

## Changes
- `wt-compiler/CHANGELOG.md`: add `v0.8.2 — 2026-06-26` entry
- `wt-compiler/pyproject.toml`: bump `[tool.pixi.package]` version `0.8.1 → 0.8.2`

No `default-env-injections.toml` floor sync needed — neither wt-task nor wt-runner is releasing. No cascading releases — nothing depends on wt-compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)