### PR TITLE
fix(wt-compiler): Use `removesuffix` instead of `rstrip` in `get_data_connection_property_names`

### DIFF
--- a/wt-compiler/src/wt_compiler/templates/pkg/metadata.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/pkg/metadata.jinja2
@@ -36,7 +36,7 @@ def get_data_connection_property_names() -> dict[str, list[str]]:
                         key = (
                             inner_v.get("$ref")
                             .lstrip("#/$defs/")
-                            .rstrip("Connection")
+                            .removesuffix("Connection")
                         )
                         if data_connections.get(key):
                             data_connections[key].append(k)

--- a/wt-compiler/src/wt_compiler/templates/pkg/metadata.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/pkg/metadata.jinja2
@@ -35,7 +35,7 @@ def get_data_connection_property_names() -> dict[str, list[str]]:
                     if ref.endswith("Connection"):
                         key = (
                             inner_v.get("$ref")
-                            .lstrip("#/$defs/")
+                            .removeprefix("#/$defs/")
                             .removesuffix("Connection")
                         )
                         if data_connections.get(key):


### PR DESCRIPTION
## :earth_americas: Summary
Closes #220

## :package: Proposed Changes
Use `removesuffix` / `removeprefix` instead of `rstrip`/`lstrip` in `get_data_connection_property_names`
