### PR TITLE
Update CHANGELOGs for release 2026-07-17

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.3 — 2026-07-17
+
+- Fix data-connection property name extraction in the generated `get_data_connection_property_names()`: use `removeprefix("#/$defs/")` / `removesuffix("Connection")` instead of `lstrip`/`rstrip`, which operate on character sets rather than literal affixes and could corrupt `$ref` names (e.g. mangling keys whose trailing characters overlap with `"Connection"`) ([#219](https://github.com/wildlife-dynamics/wt/pull/219))
+
 ## v0.8.2 — 2026-06-26
 
 - Allow custom (e.g. prefix.dev) conda channels without hardcoding them in an allowlist: explicit channel URLs in `requirements:` now pass through generically and are emitted into the generated `pixi.toml` workspace channels, while unknown bare channel names still raise to guard against typos ([#203](https://github.com/wildlife-dynamics/wt/issues/203))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -158,7 +158,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.8.2"
+version = "0.8.3"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
Release wt-compiler v0.8.3.
Closes #222

## wt-compiler v0.8.3

- Fix data-connection property name extraction in the generated `get_data_connection_property_names()`: use `removeprefix("#/$defs/")` / `removesuffix("Connection")` instead of `lstrip`/`rstrip`, which operate on character sets rather than literal affixes and could corrupt `$ref` names (#219)

🤖 Generated with [Claude Code](https://claude.com/claude-code)