### PR TITLE
feat(wt-compiler): Support updated result.json contract in conftest

### DIFF
--- a/wt-compiler/src/wt_compiler/templates/tests/conftest.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/tests/conftest.jinja2
@@ -444,10 +444,12 @@ def response_json_failure(
 
 
 def _iframe_widgets_from_response_json(response_json: dict) -> list[dict]:
-    first_view = list(response_json["result"]["views"])[0]
+    first_view_key = list(response_json["result"]["views"])[0]
+    first_view = response_json["result"]["views"][first_view_key]
+    widget_view = first_view["dashboard"] if first_view.get("dashboard") else first_view
     return [
         widget
-        for widget in response_json["result"]["views"][first_view]
+        for widget in widget_view
         if isinstance(widget["data"], str) and widget["data"].endswith(".html")
     ]
 


### PR DESCRIPTION
## :earth_americas: Summary
Closes #229 

## :package: Proposed Changes
- Small tweak to `_iframe_widgets_from_response_json` so it handles both versions of ecoscope.platform's dashboard
