### PR TITLE
Update CHANGELOGs for release 2026-08-17

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.9.0 — 2026-08-17
+
+- Add optional `metadata` field to the workflow `Spec` — new `Metadata` and `Maintainer` models for catalog discovery and attribution. Extra fields are allowed and retained, the maintainer list must be non-empty, and `metadata` is excluded from the workflow `sha256` so adding it never changes an existing workflow's hash ([#231](https://github.com/wildlife-dynamics/wt/pull/231))
+- Fix Windows path handling in the generated CLI: route `file://` results URLs through `url2pathname` before constructing the OS path ([#232](https://github.com/wildlife-dynamics/wt/pull/232))
+- Generated test `conftest` now supports both the old and new dashboard-contract JSON shapes ([#230](https://github.com/wildlife-dynamics/wt/pull/230))
+- Update generated CI/tag workflow templates: bump `actions/checkout` v6→v7 and reject invalid `0.0.0` tags ([#215](https://github.com/wildlife-dynamics/wt/pull/215))
+
 ## v0.8.3 — 2026-07-17
 
 - Fix data-connection property name extraction in the generated `get_data_connection_property_names()`: use `removeprefix("#/$defs/")` / `removesuffix("Connection")` instead of `lstrip`/`rstrip`, which operate on character sets rather than literal affixes and could corrupt `$ref` names (e.g. mangling keys whose trailing characters overlap with `"Connection"`) ([#219](https://github.com/wildlife-dynamics/wt/pull/219))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -158,7 +158,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.8.3"
+version = "0.9.0"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }

--- a/wt-invokers/CHANGELOG.md
+++ b/wt-invokers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1 — 2026-08-17
+
+- Fix Windows path handling: route `file://` results URLs through `url2pathname` before `mkdir` so paths resolve correctly on Windows; a no-op on POSIX ([#232](https://github.com/wildlife-dynamics/wt/pull/232))
+
 ## v0.5.0 — 2026-06-18
 
 - **Breaking:** `--environment-tar-digest sha256:<hex>` is now **required** on the sandbox CLI and as the `environment_tar_digest` keyword argument on `CloudRunJobsSandboxInvoker.run(...)`. The downloaded `environment.tar` is verified against this digest before unpacking; on mismatch the run **fails before unpacking, raising and exiting non-zero** (no `result.json` written), so a tampered or corrupted environment never executes. Callers populating `invoker_kwargs` for wt-runner must now include `environment_tar_digest` ([#196](https://github.com/wildlife-dynamics/wt/pull/196))

--- a/wt-invokers/pyproject.toml
+++ b/wt-invokers/pyproject.toml
@@ -194,7 +194,7 @@ exclude_lines = [
 
 [tool.pixi.package]
 name = "wt-invokers"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
Release prep for 2026-08-17.
Closes #235

## Packages

| Package | Current | New | Reason |
|---------|---------|-----|--------|
| wt-compiler | 0.8.3 | 0.9.0 | New optional `metadata` spec field (feature) + Windows path fix + CI/template updates |
| wt-invokers | 0.5.0 | 0.5.1 | Windows `file://` results-path bugfix |

GCP metapackages: none released independently. `wt-invokers-gcp` deps unchanged.

## Changes
- Prepend v0.9.0 / v0.5.1 entries to respective CHANGELOGs
- Bump `[tool.pixi.package] version` in both pyproject.toml files

No `default-env-injections.toml` floor changes (wt-task/wt-runner not released this cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)