### PR TITLE
Bump wt-invokers-gcp version to 0.5.1 for release 2026-08-17

### DIFF
--- a/wt-invokers-gcp/pyproject.toml
+++ b/wt-invokers-gcp/pyproject.toml
@@ -92,7 +92,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-invokers-gcp"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
Closes #235
Follow-up to #234: the `wt-invokers-gcp` metapackage must be released in lockstep with `wt-invokers` v0.5.1, but its `[tool.pixi.package] version` was left at 0.5.0. Since GCP metapackages are conda-only, this static version is what gets published — bumping it to 0.5.1 so the lockstep conda package publishes at the correct version.

Dependency pin (`wt-invokers>=0.1.0,<1.0.0`) unchanged — the bugfix is non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)