### PR TITLE
fix(wt-compiler): unsafe get in `_iframe_widgets_from_response_json`

### DIFF
--- a/wt-compiler/src/wt_compiler/templates/tests/conftest.jinja2
+++ b/wt-compiler/src/wt_compiler/templates/tests/conftest.jinja2
@@ -446,7 +446,7 @@ def response_json_failure(
 def _iframe_widgets_from_response_json(response_json: dict) -> list[dict]:
     first_view_key = list(response_json["result"]["views"])[0]
     first_view = response_json["result"]["views"][first_view_key]
-    widget_view = first_view["dashboard"] if first_view.get("dashboard") else first_view
+    widget_view = first_view["dashboard"] if isinstance(first_view, dict) else first_view
     return [
         widget
         for widget in widget_view


### PR DESCRIPTION
## :earth_americas: Summary
Closes #229 

## :package: Proposed Changes
The change in #230 is broken for legacy dashboards due to an unsafe `.get()`  that assumes a dict :facepalm: 
