### PR TITLE
Update CHANGELOGs for release 2026-08-21

### DIFF
--- a/wt-compiler/CHANGELOG.md
+++ b/wt-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.9.1 — 2026-08-21
+
+- Fix `_iframe_widgets_from_response_json` in the generated conftest template to properly handle both versions of the dashboard contract ([#237](https://github.com/wildlife-dynamics/wt/pull/237))
+
 ## v0.9.0 — 2026-08-17
 
 - Add optional `metadata` field to the workflow `Spec` — new `Metadata` and `Maintainer` models for catalog discovery and attribution. Extra fields are allowed and retained, the maintainer list must be non-empty, and `metadata` is excluded from the workflow `sha256` so adding it never changes an existing workflow's hash ([#231](https://github.com/wildlife-dynamics/wt/pull/231))

--- a/wt-compiler/pyproject.toml
+++ b/wt-compiler/pyproject.toml
@@ -158,7 +158,7 @@ convention = "google"
 
 [tool.pixi.package]
 name = "wt-compiler"
-version = "0.9.0"
+version = "0.9.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "*", channels = ["conda-forge", "https://prefix.dev/pixi-build-backends"] }


### PR DESCRIPTION
Closes #239
Release prep for 2026-08-21.

## Packages
| Package | Current | New | Reason |
|---------|---------|-----|--------|
| wt-compiler | 0.9.0 | 0.9.1 | Fix `_iframe_widgets_from_response_json` in the generated conftest template to properly handle both versions of the dashboard contract (#237) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)